### PR TITLE
feat(tenant): add tenant retrieval by id

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/tenant/application/TenantRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/tenant/application/TenantRepository.java
@@ -1,7 +1,11 @@
 package br.com.f2e.ovenplatform.tenant.application;
 
 import br.com.f2e.ovenplatform.tenant.domain.Tenant;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface TenantRepository {
   Tenant save(Tenant tenant);
+
+  Optional<Tenant> findById(UUID id);
 }

--- a/src/main/java/br/com/f2e/ovenplatform/tenant/application/TenantService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/tenant/application/TenantService.java
@@ -2,6 +2,8 @@ package br.com.f2e.ovenplatform.tenant.application;
 
 import br.com.f2e.ovenplatform.tenant.domain.Plan;
 import br.com.f2e.ovenplatform.tenant.domain.Tenant;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,5 +18,9 @@ public class TenantService {
   public Tenant create(String name, Plan plan) {
     var tenant = new Tenant(name, plan);
     return repository.save(tenant);
+  }
+
+  public Optional<Tenant> findById(UUID id) {
+    return repository.findById(id);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/persistence/JpaTenantRepositoryAdapter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/persistence/JpaTenantRepositoryAdapter.java
@@ -2,6 +2,8 @@ package br.com.f2e.ovenplatform.tenant.infrastructure.persistence;
 
 import br.com.f2e.ovenplatform.tenant.application.TenantRepository;
 import br.com.f2e.ovenplatform.tenant.domain.Tenant;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,5 +18,10 @@ public class JpaTenantRepositoryAdapter implements TenantRepository {
   @Override
   public Tenant save(Tenant tenant) {
     return repository.save(tenant);
+  }
+
+  @Override
+  public Optional<Tenant> findById(UUID id) {
+    return repository.findById(id);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantController.java
@@ -2,9 +2,12 @@ package br.com.f2e.ovenplatform.tenant.infrastructure.web;
 
 import br.com.f2e.ovenplatform.tenant.application.TenantService;
 import br.com.f2e.ovenplatform.tenant.infrastructure.web.dto.CreateTenantRequest;
-import br.com.f2e.ovenplatform.tenant.infrastructure.web.dto.CreateTenantResponse;
+import br.com.f2e.ovenplatform.tenant.infrastructure.web.dto.TenantResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,10 +25,18 @@ public class TenantController {
   }
 
   @PostMapping
-  public ResponseEntity<CreateTenantResponse> create(
+  public ResponseEntity<TenantResponse> create(
       @Valid @RequestBody CreateTenantRequest request) {
-    var response = CreateTenantResponse.from(tenantService.create(request.name(), request.plan()));
+    var response = TenantResponse.from(tenantService.create(request.name(), request.plan()));
     var uri = UriComponentsBuilder.fromPath("/tenants/{id}").buildAndExpand(response.id()).toUri();
     return ResponseEntity.created(uri).body(response);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<TenantResponse> findById(@PathVariable UUID id) {
+    return tenantService
+        .findById(id)
+        .map(tenant -> ResponseEntity.ok(TenantResponse.from(tenant)))
+        .orElseGet(() -> ResponseEntity.notFound().build());
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantController.java
@@ -25,8 +25,7 @@ public class TenantController {
   }
 
   @PostMapping
-  public ResponseEntity<TenantResponse> create(
-      @Valid @RequestBody CreateTenantRequest request) {
+  public ResponseEntity<TenantResponse> create(@Valid @RequestBody CreateTenantRequest request) {
     var response = TenantResponse.from(tenantService.create(request.name(), request.plan()));
     var uri = UriComponentsBuilder.fromPath("/tenants/{id}").buildAndExpand(response.id()).toUri();
     return ResponseEntity.created(uri).body(response);

--- a/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/dto/TenantResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/dto/TenantResponse.java
@@ -6,11 +6,11 @@ import br.com.f2e.ovenplatform.tenant.domain.Tenant;
 import java.time.Instant;
 import java.util.UUID;
 
-public record CreateTenantResponse(
+public record TenantResponse(
     UUID id, String name, Plan plan, Status status, Instant createdAt, Instant updatedAt) {
 
-  public static CreateTenantResponse from(Tenant tenant) {
-    return new CreateTenantResponse(
+  public static TenantResponse from(Tenant tenant) {
+    return new TenantResponse(
         tenant.getId(),
         tenant.getName(),
         tenant.getPlan(),

--- a/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
@@ -3,6 +3,7 @@ package br.com.f2e.ovenplatform.tenant.infrastructure.web;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,6 +15,7 @@ import br.com.f2e.ovenplatform.tenant.domain.Plan;
 import br.com.f2e.ovenplatform.tenant.domain.Status;
 import br.com.f2e.ovenplatform.tenant.domain.Tenant;
 import br.com.f2e.ovenplatform.tenant.infrastructure.web.dto.CreateTenantRequest;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -32,7 +34,7 @@ class TenantControllerTest {
   @Test
   void shouldCreateTenantAndReturn201WithLocationAndBody() throws Exception {
     var content = JsonUtils.toJson(new CreateTenantRequest(TENANT_NAME, Plan.MVP));
-    when(tenantService.create(TENANT_NAME, Plan.MVP)).thenReturn(new Tenant(TENANT_NAME, Plan.MVP));
+    when(tenantService.create(TENANT_NAME, Plan.MVP)).thenReturn(getTenant());
     mockMvc
         .perform(post(URL).contentType(MediaType.APPLICATION_JSON).content(content))
         .andExpect(status().isCreated())
@@ -50,5 +52,30 @@ class TenantControllerTest {
         .perform(post(URL).contentType(MediaType.APPLICATION_JSON).content(content))
         .andExpect(status().isBadRequest());
     verifyNoInteractions(tenantService);
+  }
+
+  @Test
+  void shouldReturnTenantAnd200WhenTenantExists() throws Exception {
+    var tenant = getTenant();
+    when(tenantService.findById(tenant.getId())).thenReturn(Optional.of(tenant));
+    mockMvc
+        .perform(get(URL + "/" + tenant.getId()).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.name").value(TENANT_NAME))
+        .andExpect(jsonPath("$.plan").value(Plan.MVP.name()))
+        .andExpect(jsonPath("$.status").value(Status.ACTIVE.name()));
+  }
+
+  @Test
+  void shouldReturn404WhenTenantDoesNotExist() throws Exception {
+    when(tenantService.findById(getTenant().getId())).thenReturn(Optional.empty());
+    mockMvc
+        .perform(get(URL + "/" + getTenant().getId()).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  private Tenant getTenant() {
+    return new Tenant(TENANT_NAME, Plan.MVP);
   }
 }


### PR DESCRIPTION
## Summary

Add tenant retrieval endpoint by id and extend web layer test coverage.

This PR introduces the ability to fetch a tenant by its identifier, ensuring proper HTTP semantics and consistency with existing endpoints. It also expands test coverage for the tenant module at the web layer.

---

## Changes

- Add `GET /tenants/{id}` endpoint
- Extend `TenantService` with retrieval operation
- Add `findById` to tenant repository contract
- Implement lookup in JPA repository adapter
- Return `200 OK` when tenant exists
- Return `404 Not Found` when tenant does not exist
- Rename `CreateTenantResponse` to `TenantResponse` for reuse across endpoints
- Add WebMvcTest coverage for retrieval endpoint:
  - success scenario (200 OK)
  - not found scenario (404 Not Found)

---

## Closes

Closes #28 