### PR TITLE
feat(platform): add global exception handler

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorItem.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorItem.java
@@ -1,0 +1,12 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
+
+public record ApiErrorItem(String field, String message) {
+
+  public static ApiErrorItem of(String field, String message) {
+    return new ApiErrorItem(field, message);
+  }
+
+  public static ApiErrorItem messageOnly(String message) {
+    return new ApiErrorItem(null, message);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
@@ -1,0 +1,18 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+
+public record ApiErrorResponse(
+    Instant timestamp, int status, List<ApiErrorItem> errors, String path) {
+
+  public static ApiErrorResponse of(HttpStatus status, List<ApiErrorItem> errors, String path) {
+    return new ApiErrorResponse(Instant.now(), status.value(), errors, path);
+  }
+
+  public static ApiErrorResponse of(HttpStatus status, String message, String path) {
+    return new ApiErrorResponse(
+        Instant.now(), status.value(), List.of(ApiErrorItem.messageOnly(message)), path);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
@@ -5,14 +5,19 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 
 public record ApiErrorResponse(
-    Instant timestamp, int status, List<ApiErrorItem> errors, String path) {
+    Instant timestamp, int status, String error, List<ApiErrorItem> errors, String path) {
 
   public static ApiErrorResponse of(HttpStatus status, List<ApiErrorItem> errors, String path) {
-    return new ApiErrorResponse(Instant.now(), status.value(), errors, path);
+    return new ApiErrorResponse(
+        Instant.now(), status.value(), status.getReasonPhrase(), errors, path);
   }
 
   public static ApiErrorResponse of(HttpStatus status, String message, String path) {
     return new ApiErrorResponse(
-        Instant.now(), status.value(), List.of(ApiErrorItem.messageOnly(message)), path);
+        Instant.now(),
+        status.value(),
+        status.getReasonPhrase(),
+        java.util.List.of(ApiErrorItem.messageOnly(message)),
+        path);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -1,0 +1,58 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.NoSuchElementException;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  private final MessageSource messageSource;
+
+  public GlobalExceptionHandler(MessageSource messageSource) {
+    this.messageSource = messageSource;
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ApiErrorResponse> illegalArgumentHandler(
+      IllegalArgumentException exception, HttpServletRequest request) {
+    return ResponseEntity.badRequest()
+        .body(
+            ApiErrorResponse.of(
+                HttpStatus.BAD_REQUEST, exception.getMessage(), request.getRequestURI()));
+  }
+
+  @ResponseStatus(code = HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiErrorResponse> badRequestHandler(
+      MethodArgumentNotValidException exception, HttpServletRequest request) {
+    var errors =
+        exception.getFieldErrors().stream()
+            .map(
+                error -> {
+                  String message = messageSource.getMessage(error, LocaleContextHolder.getLocale());
+                  return ApiErrorItem.of(error.getField(), message);
+                })
+            .toList();
+    return ResponseEntity.badRequest()
+        .body(ApiErrorResponse.of(HttpStatus.BAD_REQUEST, errors, request.getRequestURI()));
+  }
+
+  @ResponseStatus(code = HttpStatus.NOT_FOUND)
+  @ExceptionHandler(NoSuchElementException.class)
+  public ResponseEntity<ApiErrorResponse> notFoundHandler(
+      NoSuchElementException exception, HttpServletRequest request) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        .body(
+            ApiErrorResponse.of(
+                HttpStatus.NOT_FOUND, exception.getMessage(), request.getRequestURI()));
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -20,7 +19,6 @@ public class GlobalExceptionHandler {
     this.messageSource = messageSource;
   }
 
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<ApiErrorResponse> illegalArgumentHandler(
       IllegalArgumentException exception, HttpServletRequest request) {
@@ -30,7 +28,6 @@ public class GlobalExceptionHandler {
                 HttpStatus.BAD_REQUEST, exception.getMessage(), request.getRequestURI()));
   }
 
-  @ResponseStatus(code = HttpStatus.BAD_REQUEST)
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ApiErrorResponse> badRequestHandler(
       MethodArgumentNotValidException exception, HttpServletRequest request) {
@@ -46,7 +43,6 @@ public class GlobalExceptionHandler {
         .body(ApiErrorResponse.of(HttpStatus.BAD_REQUEST, errors, request.getRequestURI()));
   }
 
-  @ResponseStatus(code = HttpStatus.NOT_FOUND)
   @ExceptionHandler(NoSuchElementException.class)
   public ResponseEntity<ApiErrorResponse> notFoundHandler(
       NoSuchElementException exception, HttpServletRequest request) {

--- a/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantController.java
@@ -4,6 +4,7 @@ import br.com.f2e.ovenplatform.tenant.application.TenantService;
 import br.com.f2e.ovenplatform.tenant.infrastructure.web.dto.CreateTenantRequest;
 import br.com.f2e.ovenplatform.tenant.infrastructure.web.dto.TenantResponse;
 import jakarta.validation.Valid;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,6 +37,6 @@ public class TenantController {
     return tenantService
         .findById(id)
         .map(tenant -> ResponseEntity.ok(TenantResponse.from(tenant)))
-        .orElseGet(() -> ResponseEntity.notFound().build());
+        .orElseThrow(() -> new NoSuchElementException("Tenant not found"));
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -38,7 +39,7 @@ class TenantControllerTest {
     mockMvc
         .perform(post(URL).contentType(MediaType.APPLICATION_JSON).content(content))
         .andExpect(status().isCreated())
-        .andExpect(header().string("Location", containsString("/tenants/")))
+        .andExpect(header().string("Location", containsString(URL)))
         .andExpect(jsonPath("$.status").value(Status.ACTIVE.name()))
         .andExpect(jsonPath("$.name").value(TENANT_NAME))
         .andExpect(jsonPath("$.plan").value(Plan.MVP.name()))
@@ -50,7 +51,12 @@ class TenantControllerTest {
     var content = JsonUtils.toJson(new CreateTenantRequest("", Plan.MVP));
     mockMvc
         .perform(post(URL).contentType(MediaType.APPLICATION_JSON).content(content))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.path").value(URL))
+        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].message").value("must not be blank"))
+        .andExpect(jsonPath("$.errors[0].field").value("name"))
+        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
     verifyNoInteractions(tenantService);
   }
 
@@ -70,9 +76,13 @@ class TenantControllerTest {
   @Test
   void shouldReturn404WhenTenantDoesNotExist() throws Exception {
     when(tenantService.findById(getTenant().getId())).thenReturn(Optional.empty());
+    var getUrl = URL + "/" + getTenant().getId();
     mockMvc
-        .perform(get(URL + "/" + getTenant().getId()).contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNotFound());
+        .perform(get(getUrl).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.path").value(getUrl))
+        .andExpect(jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+        .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
   }
 
   private Tenant getTenant() {


### PR DESCRIPTION
## Summary

Introduce global exception handling and standardize API error responses across the platform.

This PR centralizes error handling using a global exception handler, ensuring consistent HTTP responses for validation, domain, and not found scenarios. It also refactors the tenant retrieval flow to rely on exception handling instead of manual response control and extends web layer test coverage accordingly.

---

## Changes

- Add global exception handler using `@RestControllerAdvice`
- Introduce standardized error response model (`ApiErrorResponse`, `ApiErrorItem`)
- Include `timestamp`, `status`, `error`, `errors`, and `path` in all API error responses
- Handle `IllegalArgumentException` as `400 Bad Request`
- Handle `MethodArgumentNotValidException` with field-level validation errors
- Handle `NoSuchElementException` as `404 Not Found`
- Remove redundant `@ResponseStatus` annotations where `ResponseEntity` already defines the HTTP status
- Refactor tenant retrieval to use exception-based flow for not found scenarios
- Improve and extend WebMvcTest coverage:
    - validation error scenario (`400 Bad Request`)
    - not found scenario (`404 Not Found`)
    - validation of standardized error payload fields, including `error`

---

## Closes

Closes #31