### PR TITLE
feat(identity): expose get user endpoint with tenant isolation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
                             <endWithNewline/>
                             <indent>
                                 <tabs>true</tabs>
-                                <spacesPerTab>4</spacesPerTab>
+                                <spacesPerTab>2</spacesPerTab>
                             </indent>
                         </format>
                     </formats>
@@ -191,6 +191,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>4.0.0.4121</version>
             </plugin>
         </plugins>
     </build>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,6 @@ sonar.organization=franklin-barreto
 sonar.host.url=https://sonarcloud.io
 sonar.java.binaries=target/classes
 sonar.projectVersion=1.0
-sonar.language=java
 sonar.sourceEncoding=UTF-8
 sonar.java.source=25
 sonar.java.target=25

--- a/src/main/java/br/com/f2e/ovenplatform/identity/application/IdentityService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/application/IdentityService.java
@@ -1,13 +1,14 @@
 package br.com.f2e.ovenplatform.identity.application;
 
-import br.com.f2e.ovenplatform.identity.domain.User;
-import br.com.f2e.ovenplatform.identity.domain.UserRole;
-import java.util.UUID;
-import org.springframework.stereotype.Service;
-
 import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.normalizeEmail;
 import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.requireNotBlank;
 import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.requireNotNull;
+
+import br.com.f2e.ovenplatform.identity.domain.User;
+import br.com.f2e.ovenplatform.identity.domain.UserRole;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
 
 @Service
 public class IdentityService {
@@ -26,5 +27,11 @@ public class IdentityService {
 
     var passwordHash = passwordHasher.hash(rawPassword);
     return userRepository.save(new User(tenantId, normalizeEmail(email), passwordHash, role));
+  }
+
+  public User findByIdAndTenantId(UUID id, UUID tenantId) {
+    return userRepository
+        .findByIdAndTenantId(id, tenantId)
+        .orElseThrow(() -> new NoSuchElementException("User"));
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/identity/application/UserRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/application/UserRepository.java
@@ -1,8 +1,12 @@
 package br.com.f2e.ovenplatform.identity.application;
 
 import br.com.f2e.ovenplatform.identity.domain.User;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface UserRepository {
 
   User save(User user);
+
+  Optional<User> findByIdAndTenantId(UUID tenantId, UUID id);
 }

--- a/src/main/java/br/com/f2e/ovenplatform/identity/domain/User.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/domain/User.java
@@ -1,5 +1,9 @@
 package br.com.f2e.ovenplatform.identity.domain;
 
+import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.normalizeEmail;
+import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.requireNotBlank;
+import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.requireNotNull;
+
 import br.com.f2e.ovenplatform.shared.domain.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -7,12 +11,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-
 import java.util.UUID;
-
-import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.normalizeEmail;
-import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.requireNotBlank;
-import static br.com.f2e.ovenplatform.identity.domain.validation.Preconditions.requireNotNull;
 
 @Table(
     name = "users",

--- a/src/main/java/br/com/f2e/ovenplatform/identity/domain/validation/Preconditions.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/domain/validation/Preconditions.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public final class Preconditions {
   private static final Pattern EMAIL_PATTERN =
-          Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+      Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
   private Preconditions() {}
 

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/persistence/JpaUserRepositoryAdapter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/persistence/JpaUserRepositoryAdapter.java
@@ -2,6 +2,8 @@ package br.com.f2e.ovenplatform.identity.infrastructure.persistence;
 
 import br.com.f2e.ovenplatform.identity.application.UserRepository;
 import br.com.f2e.ovenplatform.identity.domain.User;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,5 +18,10 @@ public class JpaUserRepositoryAdapter implements UserRepository {
   @Override
   public User save(User user) {
     return userRepository.save(user);
+  }
+
+  @Override
+  public Optional<User> findByIdAndTenantId(UUID id, UUID tenantId) {
+    return userRepository.findByIdAndTenantId(id, tenantId);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/persistence/SpringDataUserRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/persistence/SpringDataUserRepository.java
@@ -1,7 +1,11 @@
 package br.com.f2e.ovenplatform.identity.infrastructure.persistence;
 
 import br.com.f2e.ovenplatform.identity.domain.User;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SpringDataUserRepository extends JpaRepository<User, UUID> {}
+public interface SpringDataUserRepository extends JpaRepository<User, UUID> {
+
+  Optional<User> findByIdAndTenantId(UUID id, UUID tenantId);
+}

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -38,5 +40,12 @@ public class IdentityController {
             .buildAndExpand(userResponse.id())
             .toUri();
     return ResponseEntity.created(uri).body(userResponse);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<UserResponse> findByIdAndTenantId(
+      @RequestHeader("X-Tenant-Id") UUID tenantId, @PathVariable UUID id) {
+    return ResponseEntity.ok(
+        UserResponse.fromEntity(identityService.findByIdAndTenantId(id, tenantId)));
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -73,7 +73,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(NotAcceptableApiVersionException.class)
   public ResponseEntity<ApiErrorResponse> notAcceptableApiVersionHandler(
-          NotAcceptableApiVersionException exception, HttpServletRequest request) {
+      NotAcceptableApiVersionException exception, HttpServletRequest request) {
     return error(HttpStatus.BAD_REQUEST, exception.getMessage(), request);
   }
 

--- a/src/test/java/br/com/f2e/ovenplatform/identity/application/IdentityServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/application/IdentityServiceIntegrationTest.java
@@ -28,10 +28,10 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @Import({
-        IdentityService.class,
-        BCryptPasswordHasher.class,
-        JpaUserRepositoryAdapter.class,
-        SecurityConfig.class
+  IdentityService.class,
+  BCryptPasswordHasher.class,
+  JpaUserRepositoryAdapter.class,
+  SecurityConfig.class
 })
 @EnableJpaAuditing
 class IdentityServiceIntegrationTest {
@@ -107,7 +107,7 @@ class IdentityServiceIntegrationTest {
         IllegalArgumentException.class,
         () ->
             identityService.create(
-                    tenantId, "invalidEmailOutlook.com", RAW_PASSWORD, UserRole.MEMBER));
+                tenantId, "invalidEmailOutlook.com", RAW_PASSWORD, UserRole.MEMBER));
   }
 
   private Tenant createTenant() {

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
@@ -3,6 +3,7 @@ package br.com.f2e.ovenplatform.identity.infrastructure.web;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,6 +15,7 @@ import br.com.f2e.ovenplatform.identity.domain.UserRole;
 import br.com.f2e.ovenplatform.identity.domain.UserStatus;
 import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserRequest;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -34,6 +36,7 @@ class IdentityControllerTest {
   private static final String EMAIL = "user.email@outlook.com";
   private static final String PASSWORD = "1234";
   private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
+  private static final UUID USER_ID = UUID.fromString("b5b6c3d2-3f69-45c5-8a4b-8d6d8a9c1234");
   private static final String URL = "/users";
 
   @Autowired private MockMvc mockMvc;
@@ -41,11 +44,11 @@ class IdentityControllerTest {
 
   @Test
   void shouldCreateUserSuccessfully() throws Exception {
-
     when(identityService.create(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER))
-        .thenReturn(new User(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER));
+        .thenReturn(getUserEntity());
 
-    var userRequest = new UserRequest(EMAIL, PASSWORD, UserRole.MEMBER);
+    var userRequest = createUserRequest();
+
     mockMvc
         .perform(
             post(URL)
@@ -61,10 +64,9 @@ class IdentityControllerTest {
   }
 
   @ParameterizedTest
-  @MethodSource("invalidRequests")
-  void shouldReturnValidationErrors(UserRequest request, String field, String message)
+  @MethodSource("invalidRequestsCreate")
+  void shouldReturn400WhenCreateRequestIsInvalid(UserRequest request, String field, String message)
       throws Exception {
-
     mockMvc
         .perform(
             post(URL)
@@ -72,7 +74,6 @@ class IdentityControllerTest {
                 .content(JsonUtils.toJson(request))
                 .header("X-Tenant-Id", TENANT_ID)
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isBadRequest())
         .andExpectAll(
             validationErrors(
                 HttpStatus.BAD_REQUEST,
@@ -86,8 +87,8 @@ class IdentityControllerTest {
   }
 
   @Test
-  void shouldReturn400WhenTenantIdHeaderIsInvalid() throws Exception {
-    var userRequest = new UserRequest(EMAIL, PASSWORD, UserRole.MEMBER);
+  void shouldReturn400WhenCreateTenantIdHeaderIsInvalid() throws Exception {
+    var userRequest = createUserRequest();
 
     mockMvc
         .perform(
@@ -102,14 +103,14 @@ class IdentityControllerTest {
                 HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 "Invalid UUID string: invalid-uuid",
                 null,
-                HttpStatus.BAD_REQUEST.value()))
-        .andExpect(status().isBadRequest());
+                HttpStatus.BAD_REQUEST.value()));
+
     verifyNoInteractions(identityService);
   }
 
   @Test
-  void shouldReturn400WhenTenantIdHeaderIsMissing() throws Exception {
-    var userRequest = new UserRequest(EMAIL, PASSWORD, UserRole.MEMBER);
+  void shouldReturn400WhenCreateTenantIdHeaderIsMissing() throws Exception {
+    var userRequest = createUserRequest();
 
     mockMvc
         .perform(
@@ -117,6 +118,79 @@ class IdentityControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(userRequest)))
         .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(identityService);
+  }
+
+  @Test
+  void shouldReturn200WhenUserExists() throws Exception {
+    when(identityService.findByIdAndTenantId(USER_ID, TENANT_ID)).thenReturn(getUserEntity());
+
+    mockMvc
+        .perform(
+            get(URL + "/%s".formatted(USER_ID))
+                .header("X-Tenant-Id", TENANT_ID)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value(UserStatus.ACTIVE.name()))
+        .andExpect(jsonPath("$.email").value(EMAIL))
+        .andExpect(jsonPath("$.tenantId").value(TENANT_ID.toString()));
+  }
+
+  @Test
+  void shouldReturn404WhenUserDoesNotExist() throws Exception {
+    var getUrl = URL + "/" + USER_ID;
+
+    when(identityService.findByIdAndTenantId(USER_ID, TENANT_ID))
+        .thenThrow(new NoSuchElementException("User"));
+
+    mockMvc
+        .perform(
+            get(getUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Tenant-Id", TENANT_ID)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.path").value(getUrl))
+        .andExpect(jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+        .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+  }
+
+  @Test
+  void shouldReturn400WhenGetTenantIdHeaderIsMissing() throws Exception {
+
+    var getUrl = URL + "/" + USER_ID;
+    mockMvc
+        .perform(get(getUrl).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(identityService);
+  }
+
+  @Test
+  void shouldReturn400WhenGetTenantIdHeaderIsInvalid() throws Exception {
+    var getUrl = URL + "/" + USER_ID;
+    mockMvc
+        .perform(
+            get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", "invalid tenant"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(identityService);
+  }
+
+  @Test
+  void shouldReturn400WhenUserIdIsInvalid() throws Exception {
+    var getUrl = URL + "/" + "invalidUserId";
+    mockMvc
+        .perform(get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", TENANT_ID))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+
     verifyNoInteractions(identityService);
   }
 
@@ -137,7 +211,7 @@ class IdentityControllerTest {
     };
   }
 
-  private static Stream<Arguments> invalidRequests() {
+  private static Stream<Arguments> invalidRequestsCreate() {
     return Stream.of(
         Arguments.of(
             new UserRequest("invalidEmail.com", "1234", UserRole.MEMBER),
@@ -148,5 +222,13 @@ class IdentityControllerTest {
             "password",
             "must not be blank"),
         Arguments.of(new UserRequest("user@email.com", "1234", null), "role", "must not be null"));
+  }
+
+  private static UserRequest createUserRequest() {
+    return new UserRequest(EMAIL, PASSWORD, UserRole.MEMBER);
+  }
+
+  private static User getUserEntity() {
+    return new User(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER);
   }
 }


### PR DESCRIPTION
## Summary

Expose the user retrieval HTTP endpoint in the identity module.

This PR introduces the `GET /users/{id}` endpoint, enabling clients to retrieve user data scoped to a tenant. It ensures proper handling of tenant context via headers, integrates with the global exception handler, and provides consistent and secure API responses.

---

## Changes

- Add `GET /users/{id}` endpoint in `IdentityController`
- Retrieve user by id scoped to tenant using `X-Tenant-Id` header
- Delegate retrieval logic to `IdentityService`
- Return `200 OK` with `UserResponse` when user exists
- Return `404 Not Found` when user is not found within the tenant
- Ensure response does not expose internal fields (e.g. `passwordHash`)
- Integrate with global exception handler for standardized error responses
- Add WebMvc tests for success and not found scenarios

---

## Validation

- Verified successful retrieval returns `200 OK` with correct user data
- Verified non-existing user returns `404 Not Found`
- Verified tenant isolation is enforced (user must belong to tenant)
- Verified missing `X-Tenant-Id` returns `400 Bad Request`
- Verified invalid `X-Tenant-Id` returns `400 Bad Request`
- Verified response does not expose sensitive fields
- Verified controller delegates retrieval to `IdentityService`

---

Closes #38