### PR TITLE
test(identity): add integration tests for user retrieval with tenant …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,48 +1,36 @@
-name: CI
-
+name: SonarQube
 on:
-  pull_request:
   push:
-    branches: [ "main" ]
-
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 jobs:
   build:
-    name: Build and Coverage
+    name: Build and analyze
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
           java-version: 25
-          cache: maven
-
-      - name: Build, test and verify coverage
-        run: ./mvnw clean verify
-
-  sonar:
-    name: Sonar
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+          distribution: 'zulu' # Alternative distribution options are available.
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
         with:
-          fetch-depth: 0
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@v4
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v4
         with:
-          distribution: temurin
-          java-version: 25
-          cache: maven
-
-      - name: Build and run Sonar analysis
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./mvnw clean verify sonar:sonar
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=Franklin-Barreto_oven-platform

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,14 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.build.directory}/site/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.projectKey>Franklin-Barreto_oven-platform</sonar.projectKey>
+        <sonar.organization>franklin-barreto</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.java.binaries>${project.build.outputDirectory}</sonar.java.binaries>
+        <sonar.projectVersion>1.0</sonar.projectVersion>
+        <sonar.sourceEncoding>UTF-8</sonar.sourceEncoding>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
     <dependencies>
         <dependency>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,0 @@
-sonar.projectKey=Franklin-Barreto_oven-platform
-sonar.organization=franklin-barreto
-sonar.host.url=https://sonarcloud.io
-sonar.java.binaries=target/classes
-sonar.projectVersion=1.0
-sonar.sourceEncoding=UTF-8
-sonar.java.source=25
-sonar.java.target=25

--- a/src/test/java/br/com/f2e/ovenplatform/identity/application/IdentityServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/application/IdentityServiceIntegrationTest.java
@@ -28,10 +28,10 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @Import({
-  IdentityService.class,
-  BCryptPasswordHasher.class,
-  JpaUserRepositoryAdapter.class,
-  SecurityConfig.class
+        IdentityService.class,
+        BCryptPasswordHasher.class,
+        JpaUserRepositoryAdapter.class,
+        SecurityConfig.class
 })
 @EnableJpaAuditing
 class IdentityServiceIntegrationTest {
@@ -40,6 +40,7 @@ class IdentityServiceIntegrationTest {
   private static final String RAW_PASSWORD = "my-secret-password";
 
   @Autowired private IdentityService identityService;
+  @Autowired private UserRepository repository;
   @Autowired private SpringDataTenantRepository tenantRepository;
   @Autowired private SpringDataUserRepository userRepository;
 
@@ -47,7 +48,7 @@ class IdentityServiceIntegrationTest {
   void shouldCreateUserSuccessfully() {
     var tenant = createTenant();
 
-    var user = createUserAndFlush(tenant.getId(), EMAIL, RAW_PASSWORD, UserRole.ADMIN);
+    var user = createUserAndFlush(tenant.getId(), EMAIL, UserRole.ADMIN);
 
     assertUser(user, tenant, UserRole.ADMIN);
   }
@@ -56,7 +57,7 @@ class IdentityServiceIntegrationTest {
   void shouldHashPasswordBeforePersistingUser() {
     var tenant = createTenant();
 
-    var user = createUserAndFlush(tenant.getId(), EMAIL, RAW_PASSWORD, UserRole.ADMIN);
+    var user = createUserAndFlush(tenant.getId(), EMAIL, UserRole.ADMIN);
 
     assertNotEquals(RAW_PASSWORD, user.getPasswordHash());
     assertFalse(user.getPasswordHash().isBlank());
@@ -67,7 +68,7 @@ class IdentityServiceIntegrationTest {
   void shouldThrowExceptionForDuplicateEmailWithinSameTenant() {
     var tenant = createTenant();
 
-    createUserAndFlush(tenant.getId(), EMAIL, RAW_PASSWORD, UserRole.ADMIN);
+    createUserAndFlush(tenant.getId(), EMAIL, UserRole.ADMIN);
 
     identityService.create(tenant.getId(), EMAIL, UUID.randomUUID().toString(), UserRole.OWNER);
 
@@ -79,8 +80,8 @@ class IdentityServiceIntegrationTest {
     var tenantA = createTenant();
     var tenantB = createTenant();
 
-    var user = createUserAndFlush(tenantA.getId(), EMAIL, RAW_PASSWORD, UserRole.ADMIN);
-    var user2 = createUserAndFlush(tenantB.getId(), EMAIL, RAW_PASSWORD, UserRole.OWNER);
+    var user = createUserAndFlush(tenantA.getId(), EMAIL, UserRole.ADMIN);
+    var user2 = createUserAndFlush(tenantB.getId(), EMAIL, UserRole.OWNER);
 
     assertUser(user, tenantA, UserRole.ADMIN);
     assertUser(user2, tenantB, UserRole.OWNER);
@@ -91,7 +92,7 @@ class IdentityServiceIntegrationTest {
     var tenant = createTenant();
 
     var user =
-        createUserAndFlush(tenant.getId(), " Contact@email.com", RAW_PASSWORD, UserRole.ADMIN);
+            createUserAndFlush(tenant.getId(), " Contact@email.com", UserRole.ADMIN);
 
     assertEquals(EMAIL, user.getEmail());
     assertEquals(tenant.getId(), user.getTenantId());
@@ -104,18 +105,50 @@ class IdentityServiceIntegrationTest {
     var tenantId = createTenant().getId();
 
     assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            identityService.create(
-                tenantId, "invalidEmailOutlook.com", RAW_PASSWORD, UserRole.MEMBER));
+            IllegalArgumentException.class,
+            () ->
+                    identityService.create(
+                            tenantId, "invalidEmailOutlook.com", RAW_PASSWORD, UserRole.MEMBER));
+  }
+
+  @Test
+  void shouldFindUserByIdAndTenantId() {
+    var tenant = createTenant();
+    var user = createUserAndFlush(tenant.getId(), EMAIL, UserRole.ADMIN);
+
+    var result = repository.findByIdAndTenantId(user.getId(), tenant.getId());
+
+    assertTrue(result.isPresent());
+    assertUser(result.get(), tenant, UserRole.ADMIN);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenUserDoesNotExist() {
+    var tenant = createTenant();
+
+    var result = repository.findByIdAndTenantId(UUID.randomUUID(), tenant.getId());
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void shouldReturnEmptyWhenUserBelongsToAnotherTenant() {
+    var tenantA = createTenant();
+    var tenantB = createTenant();
+
+    var user = createUserAndFlush(tenantA.getId(), EMAIL, UserRole.ADMIN);
+
+    var result = repository.findByIdAndTenantId(user.getId(), tenantB.getId());
+
+    assertTrue(result.isEmpty());
   }
 
   private Tenant createTenant() {
     return tenantRepository.save(new Tenant("Don Corleone Pizzeria", Plan.MVP));
   }
 
-  private User createUserAndFlush(UUID tenantId, String email, String rawPassword, UserRole role) {
-    var user = identityService.create(tenantId, email, rawPassword, role);
+  private User createUserAndFlush(UUID tenantId, String email, UserRole role) {
+    var user = identityService.create(tenantId, email, IdentityServiceIntegrationTest.RAW_PASSWORD, role);
     userRepository.flush();
     return user;
   }


### PR DESCRIPTION
## Summary

Add integration tests for user retrieval in the identity module.

This PR introduces `@DataJpaTest`-based tests to validate the behavior of retrieving users by id within a tenant context, ensuring correct enforcement of multi-tenant isolation at the persistence layer.

---

## Changes

- Add integration tests for user retrieval scenarios
- Verify successful retrieval when `id` and `tenantId` match
- Verify empty result when user does not exist
- Verify empty result when user belongs to a different tenant
- Ensure tenant isolation is enforced at the database/query level
- Align test structure with existing identity integration tests

---

## Validation

- Verified user is retrieved when `id` and `tenantId` match
- Verified empty result when user does not exist
- Verified empty result when user belongs to another tenant
- Verified tests run against real database (H2 PostgreSQL mode)

---

Closes #40 