### PR TITLE
refactor(platform): standardize API error contract

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
@@ -42,7 +42,7 @@ public class IdentityController {
     return ResponseEntity.created(uri).body(userResponse);
   }
 
-  @GetMapping("/{id}")
+  @GetMapping(value = "/{id}", version = "1.0")
   public ResponseEntity<UserResponse> findByIdAndTenantId(
       @RequestHeader("X-Tenant-Id") UUID tenantId, @PathVariable UUID id) {
     return ResponseEntity.ok(

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorCodes.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorCodes.java
@@ -1,0 +1,15 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
+
+public final class ApiErrorCodes {
+
+  public static final String INVALID_ARGUMENT = "INVALID_ARGUMENT";
+  public static final String VALIDATION_ERROR = "VALIDATION_ERROR";
+  public static final String RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND";
+  public static final String DUPLICATE_USER_EMAIL = "DUPLICATE_USER_EMAIL";
+  public static final String TENANT_NOT_FOUND = "TENANT_NOT_FOUND";
+  public static final String DATA_INTEGRITY_VIOLATION = "DATA_INTEGRITY_VIOLATION";
+  public static final String MISSING_REQUEST_HEADER = "MISSING_REQUEST_HEADER";
+  public static final String INVALID_API_VERSION = "INVALID_API_VERSION";
+
+  private ApiErrorCodes() {}
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorItem.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorItem.java
@@ -1,12 +1,12 @@
 package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
 
-public record ApiErrorItem(String field, String message) {
+public record ApiErrorItem(String code, String field, String message) {
 
-  public static ApiErrorItem of(String field, String message) {
-    return new ApiErrorItem(field, message);
+  public static ApiErrorItem of(String code, String field, String message) {
+    return new ApiErrorItem(code, field, message);
   }
 
-  public static ApiErrorItem messageOnly(String message) {
-    return new ApiErrorItem(null, message);
+  public static ApiErrorItem messageOnly(String code, String message) {
+    return new ApiErrorItem(code, null, message);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
@@ -12,12 +12,12 @@ public record ApiErrorResponse(
         Instant.now(), status.value(), status.getReasonPhrase(), errors, path);
   }
 
-  public static ApiErrorResponse of(HttpStatus status, String message, String path) {
+  public static ApiErrorResponse of(HttpStatus status, String code, String message, String path) {
     return new ApiErrorResponse(
         Instant.now(),
         status.value(),
         status.getReasonPhrase(),
-        List.of(ApiErrorItem.messageOnly(message)),
+        List.of(ApiErrorItem.messageOnly(code, message)),
         path);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -3,9 +3,7 @@ package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
-import org.postgresql.util.PSQLException;
-import org.postgresql.util.ServerErrorMessage;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -57,24 +55,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(DataIntegrityViolationException.class)
   public ResponseEntity<ApiErrorResponse> dataIntegrityViolationHandler(
       DataIntegrityViolationException exception, HttpServletRequest request) {
-    return switch (getConstraintName(exception)) {
-      case "uk_users_tenant_id_email" ->
-          error(
-              HttpStatus.CONFLICT,
-              ApiErrorCodes.DUPLICATE_USER_EMAIL,
-              "A user with this email already exists.",
-              request);
-
-      case "fk_users_tenant_id" ->
-          error(HttpStatus.NOT_FOUND, ApiErrorCodes.TENANT_NOT_FOUND, "Tenant not found.", request);
-
-      case null, default ->
-          error(
-              HttpStatus.CONFLICT,
-              ApiErrorCodes.DATA_INTEGRITY_VIOLATION,
-              "Data integrity violation.",
-              request);
-    };
+    return handleConstraintViolation(getConstraintName(exception), request);
   }
 
   @ExceptionHandler(MissingRequestHeaderException.class)
@@ -94,16 +75,17 @@ public class GlobalExceptionHandler {
         HttpStatus.BAD_REQUEST, ApiErrorCodes.INVALID_API_VERSION, exception.getMessage(), request);
   }
 
-  private String getConstraintName(Throwable ex) {
-    Throwable cause = ex;
-    while (cause != null) {
-      if (cause instanceof PSQLException psqlEx) {
-        return Optional.ofNullable(psqlEx.getServerErrorMessage())
-            .map(ServerErrorMessage::getConstraint)
-            .orElse(null);
-      }
-      cause = cause.getCause();
+  private String getConstraintName(DataIntegrityViolationException exception) {
+    var cause = exception.getCause();
+    if (cause instanceof ConstraintViolationException constraintViolationException) {
+      return constraintViolationException.getConstraintName();
     }
+
+    if (cause != null
+        && cause.getCause() instanceof ConstraintViolationException constraintViolationException) {
+      return constraintViolationException.getConstraintName();
+    }
+
     return null;
   }
 
@@ -117,5 +99,27 @@ public class GlobalExceptionHandler {
       HttpStatus status, List<ApiErrorItem> errors, HttpServletRequest request) {
     return ResponseEntity.status(status)
         .body(ApiErrorResponse.of(status, errors, request.getRequestURI()));
+  }
+
+  private ResponseEntity<ApiErrorResponse> handleConstraintViolation(
+      String constraintName, HttpServletRequest request) {
+    return switch (constraintName) {
+      case "uk_users_tenant_id_email" ->
+          error(
+              HttpStatus.CONFLICT,
+              ApiErrorCodes.DUPLICATE_USER_EMAIL,
+              "A user with this email already exists.",
+              request);
+
+      case "fk_users_tenant_id" ->
+          error(HttpStatus.NOT_FOUND, ApiErrorCodes.TENANT_NOT_FOUND, "Tenant not found.", request);
+
+      case null, default ->
+          error(
+              HttpStatus.CONFLICT,
+              ApiErrorCodes.DATA_INTEGRITY_VIOLATION,
+              "Data integrity violation.",
+              request);
+    };
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -29,7 +29,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<ApiErrorResponse> illegalArgumentHandler(
       IllegalArgumentException exception, HttpServletRequest request) {
-    return error(HttpStatus.BAD_REQUEST, exception.getMessage(), request);
+    return error(
+        HttpStatus.BAD_REQUEST, ApiErrorCodes.INVALID_ARGUMENT, exception.getMessage(), request);
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -40,7 +41,7 @@ public class GlobalExceptionHandler {
             .map(
                 error -> {
                   String message = messageSource.getMessage(error, LocaleContextHolder.getLocale());
-                  return ApiErrorItem.of(error.getField(), message);
+                  return ApiErrorItem.of(ApiErrorCodes.VALIDATION_ERROR, error.getField(), message);
                 })
             .toList();
     return error(HttpStatus.BAD_REQUEST, errors, request);
@@ -49,7 +50,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(NoSuchElementException.class)
   public ResponseEntity<ApiErrorResponse> notFoundHandler(
       NoSuchElementException exception, HttpServletRequest request) {
-    return error(HttpStatus.NOT_FOUND, exception.getMessage(), request);
+    return error(
+        HttpStatus.NOT_FOUND, ApiErrorCodes.RESOURCE_NOT_FOUND, exception.getMessage(), request);
   }
 
   @ExceptionHandler(DataIntegrityViolationException.class)
@@ -57,24 +59,39 @@ public class GlobalExceptionHandler {
       DataIntegrityViolationException exception, HttpServletRequest request) {
     return switch (getConstraintName(exception)) {
       case "uk_users_tenant_id_email" ->
-          error(HttpStatus.CONFLICT, "A user with this email already exists.", request);
+          error(
+              HttpStatus.CONFLICT,
+              ApiErrorCodes.DUPLICATE_USER_EMAIL,
+              "A user with this email already exists.",
+              request);
 
-      case "fk_users_tenant_id" -> error(HttpStatus.NOT_FOUND, "Tenant not found.", request);
+      case "fk_users_tenant_id" ->
+          error(HttpStatus.NOT_FOUND, ApiErrorCodes.TENANT_NOT_FOUND, "Tenant not found.", request);
 
-      case null, default -> error(HttpStatus.CONFLICT, "Data integrity violation.", request);
+      case null, default ->
+          error(
+              HttpStatus.CONFLICT,
+              ApiErrorCodes.DATA_INTEGRITY_VIOLATION,
+              "Data integrity violation.",
+              request);
     };
   }
 
   @ExceptionHandler(MissingRequestHeaderException.class)
   public ResponseEntity<ApiErrorResponse> missingHeaderHandler(
       MissingRequestHeaderException exception, HttpServletRequest request) {
-    return error(HttpStatus.BAD_REQUEST, exception.getMessage(), request);
+    return error(
+        HttpStatus.BAD_REQUEST,
+        ApiErrorCodes.MISSING_REQUEST_HEADER,
+        exception.getMessage(),
+        request);
   }
 
   @ExceptionHandler(NotAcceptableApiVersionException.class)
   public ResponseEntity<ApiErrorResponse> notAcceptableApiVersionHandler(
       NotAcceptableApiVersionException exception, HttpServletRequest request) {
-    return error(HttpStatus.BAD_REQUEST, exception.getMessage(), request);
+    return error(
+        HttpStatus.BAD_REQUEST, ApiErrorCodes.INVALID_API_VERSION, exception.getMessage(), request);
   }
 
   private String getConstraintName(Throwable ex) {
@@ -91,9 +108,9 @@ public class GlobalExceptionHandler {
   }
 
   private ResponseEntity<ApiErrorResponse> error(
-      HttpStatus status, String message, HttpServletRequest request) {
+      HttpStatus status, String code, String message, HttpServletRequest request) {
     return ResponseEntity.status(status)
-        .body(ApiErrorResponse.of(status, message, request.getRequestURI()));
+        .body(ApiErrorResponse.of(status, code, message, request.getRequestURI()));
   }
 
   private ResponseEntity<ApiErrorResponse> error(

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.accept.InvalidApiVersionException;
 import org.springframework.web.accept.NotAcceptableApiVersionException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -66,6 +67,13 @@ public class GlobalExceptionHandler {
         ApiErrorCodes.MISSING_REQUEST_HEADER,
         exception.getMessage(),
         request);
+  }
+
+  @ExceptionHandler(InvalidApiVersionException.class)
+  public ResponseEntity<ApiErrorResponse> invalidApiVersionHandler(
+      InvalidApiVersionException exception, HttpServletRequest request) {
+    return error(
+        HttpStatus.BAD_REQUEST, ApiErrorCodes.INVALID_API_VERSION, exception.getMessage(), request);
   }
 
   @ExceptionHandler(NotAcceptableApiVersionException.class)

--- a/src/test/java/br/com/f2e/ovenplatform/identity/application/IdentityServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/application/IdentityServiceIntegrationTest.java
@@ -29,10 +29,10 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @ActiveProfiles("test")
 @Import({
-        IdentityService.class,
-        BCryptPasswordHasher.class,
-        JpaUserRepositoryAdapter.class,
-        SecurityConfig.class
+  IdentityService.class,
+  BCryptPasswordHasher.class,
+  JpaUserRepositoryAdapter.class,
+  SecurityConfig.class
 })
 @EnableJpaAuditing
 class IdentityServiceIntegrationTest {
@@ -104,10 +104,10 @@ class IdentityServiceIntegrationTest {
     var tenantId = createTenant().getId();
 
     assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                    identityService.create(
-                            tenantId, "invalidEmailOutlook.com", RAW_PASSWORD, UserRole.MEMBER));
+        IllegalArgumentException.class,
+        () ->
+            identityService.create(
+                tenantId, "invalidEmailOutlook.com", RAW_PASSWORD, UserRole.MEMBER));
   }
 
   @Test
@@ -126,9 +126,9 @@ class IdentityServiceIntegrationTest {
     UUID userId = UUID.randomUUID();
 
     var exception =
-            assertThrows(
-                    NoSuchElementException.class,
-                    () -> identityService.findByIdAndTenantId(userId, tenantId));
+        assertThrows(
+            NoSuchElementException.class,
+            () -> identityService.findByIdAndTenantId(userId, tenantId));
 
     assertEquals("User", exception.getMessage());
   }
@@ -140,9 +140,9 @@ class IdentityServiceIntegrationTest {
     var userId = createUserAndFlush(tenantA.getId(), EMAIL, UserRole.ADMIN).getId();
 
     var exception =
-            assertThrows(
-                    NoSuchElementException.class,
-                    () -> identityService.findByIdAndTenantId(userId, tenantBId));
+        assertThrows(
+            NoSuchElementException.class,
+            () -> identityService.findByIdAndTenantId(userId, tenantBId));
 
     assertEquals("User", exception.getMessage());
   }
@@ -153,7 +153,7 @@ class IdentityServiceIntegrationTest {
 
   private User createUserAndFlush(UUID tenantId, String email, UserRole role) {
     var user =
-            identityService.create(tenantId, email, IdentityServiceIntegrationTest.RAW_PASSWORD, role);
+        identityService.create(tenantId, email, IdentityServiceIntegrationTest.RAW_PASSWORD, role);
     userRepository.flush();
     return user;
   }

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
@@ -14,16 +14,19 @@ import br.com.f2e.ovenplatform.identity.domain.User;
 import br.com.f2e.ovenplatform.identity.domain.UserRole;
 import br.com.f2e.ovenplatform.identity.domain.UserStatus;
 import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserRequest;
+import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -79,6 +82,7 @@ class IdentityControllerTest {
                 HttpStatus.BAD_REQUEST,
                 URL,
                 HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.VALIDATION_ERROR,
                 message,
                 field,
                 HttpStatus.BAD_REQUEST.value()));
@@ -101,6 +105,7 @@ class IdentityControllerTest {
                 HttpStatus.BAD_REQUEST,
                 URL,
                 HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.INVALID_ARGUMENT,
                 "Invalid UUID string: invalid-uuid",
                 null,
                 HttpStatus.BAD_REQUEST.value()));
@@ -117,7 +122,11 @@ class IdentityControllerTest {
             post(URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(userRequest)))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.path").value(URL))
+        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.MISSING_REQUEST_HEADER))
+        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
   }
@@ -153,17 +162,20 @@ class IdentityControllerTest {
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.path").value(getUrl))
         .andExpect(jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.RESOURCE_NOT_FOUND))
         .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
   }
 
   @Test
   void shouldReturn400WhenGetTenantIdHeaderIsMissing() throws Exception {
-
     var getUrl = URL + "/" + USER_ID;
+
     mockMvc
         .perform(get(getUrl).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.path").value(getUrl))
         .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.MISSING_REQUEST_HEADER))
         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
@@ -172,11 +184,14 @@ class IdentityControllerTest {
   @Test
   void shouldReturn400WhenGetTenantIdHeaderIsInvalid() throws Exception {
     var getUrl = URL + "/" + USER_ID;
+
     mockMvc
         .perform(
             get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", "invalid tenant"))
         .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.path").value(getUrl))
         .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.INVALID_ARGUMENT))
         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
@@ -185,19 +200,67 @@ class IdentityControllerTest {
   @Test
   void shouldReturn400WhenUserIdIsInvalid() throws Exception {
     var getUrl = URL + "/" + "invalidUserId";
+
     mockMvc
         .perform(get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", TENANT_ID))
         .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.path").value(getUrl))
         .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.INVALID_ARGUMENT))
         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
+  }
+
+  @Test
+  void shouldReturn409WhenEmailAlreadyExists() throws Exception {
+    when(identityService.create(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER))
+            .thenThrow(dataIntegrityViolationException("uk_users_tenant_id_email"));
+
+    var userRequest = createUserRequest();
+
+    mockMvc
+            .perform(
+                    post(URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(JsonUtils.toJson(userRequest))
+                            .header("X-Tenant-Id", TENANT_ID)
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.path").value(URL))
+            .andExpect(jsonPath("$.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
+            .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.DUPLICATE_USER_EMAIL))
+            .andExpect(jsonPath("$.errors[0].message").value("A user with this email already exists."))
+            .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()));
+  }
+
+  @Test
+  void shouldReturn404WhenTenantDoesNotExistDuringUserCreation() throws Exception {
+    when(identityService.create(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER))
+            .thenThrow(dataIntegrityViolationException("fk_users_tenant_id"));
+
+    var userRequest = createUserRequest();
+
+    mockMvc
+            .perform(
+                    post(URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(JsonUtils.toJson(userRequest))
+                            .header("X-Tenant-Id", TENANT_ID)
+                            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.path").value(URL))
+            .andExpect(jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+            .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.TENANT_NOT_FOUND))
+            .andExpect(jsonPath("$.errors[0].message").value("Tenant not found."))
+            .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
   }
 
   private ResultMatcher[] validationErrors(
       HttpStatus httpStatus,
       String path,
       String error,
+      String code,
       String message,
       String field,
       int statusCode) {
@@ -205,6 +268,7 @@ class IdentityControllerTest {
       status().is(httpStatus.value()),
       jsonPath("$.path").value(path),
       jsonPath("$.error").value(error),
+      jsonPath("$.errors[0].code").value(code),
       jsonPath("$.errors[0].message").value(message),
       jsonPath("$.errors[0].field").value(field),
       jsonPath("$.status").value(statusCode)
@@ -230,5 +294,12 @@ class IdentityControllerTest {
 
   private static User getUserEntity() {
     return new User(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER);
+  }
+
+  private static DataIntegrityViolationException dataIntegrityViolationException(
+          String constraintName) {
+    return new DataIntegrityViolationException(
+            "data integrity violation",
+            new ConstraintViolationException("constraint violation", null, constraintName));
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
@@ -122,11 +122,15 @@ class IdentityControllerTest {
             post(URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(userRequest)))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.path").value(URL))
-        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
-        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.MISSING_REQUEST_HEADER))
-        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                URL,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.MISSING_REQUEST_HEADER,
+                "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
   }
@@ -159,11 +163,15 @@ class IdentityControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("X-Tenant-Id", TENANT_ID)
                 .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.path").value(getUrl))
-        .andExpect(jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
-        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.RESOURCE_NOT_FOUND))
-        .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.NOT_FOUND,
+                getUrl,
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ApiErrorCodes.RESOURCE_NOT_FOUND,
+                "User",
+                null,
+                HttpStatus.NOT_FOUND.value()));
   }
 
   @Test
@@ -172,11 +180,15 @@ class IdentityControllerTest {
 
     mockMvc
         .perform(get(getUrl).accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.path").value(getUrl))
-        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
-        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.MISSING_REQUEST_HEADER))
-        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                getUrl,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.MISSING_REQUEST_HEADER,
+                "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
   }
@@ -188,11 +200,15 @@ class IdentityControllerTest {
     mockMvc
         .perform(
             get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", "invalid tenant"))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.path").value(getUrl))
-        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
-        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.INVALID_ARGUMENT))
-        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                getUrl,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.INVALID_ARGUMENT,
+                "Invalid UUID string: invalid tenant",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
   }
@@ -203,57 +219,93 @@ class IdentityControllerTest {
 
     mockMvc
         .perform(get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", TENANT_ID))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.path").value(getUrl))
-        .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
-        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.INVALID_ARGUMENT))
-        .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                getUrl,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.INVALID_ARGUMENT,
+                "Invalid UUID string: invalidUserId",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(identityService);
+  }
+
+  @ParameterizedTest
+  @MethodSource("dataIntegrityViolationScenarios")
+  void shouldHandleDataIntegrityViolationDuringUserCreation(
+      DataIntegrityViolationException exception,
+      HttpStatus expectedStatus,
+      String expectedCode,
+      String expectedMessage)
+      throws Exception {
+    when(identityService.create(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER)).thenThrow(exception);
+
+    var userRequest = createUserRequest();
+
+    mockMvc
+        .perform(
+            post(URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtils.toJson(userRequest))
+                .header("X-Tenant-Id", TENANT_ID)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpectAll(
+            validationErrors(
+                expectedStatus,
+                URL,
+                expectedStatus.getReasonPhrase(),
+                expectedCode,
+                expectedMessage,
+                null,
+                expectedStatus.value()));
+  }
+
+  @Test
+  void shouldReturn400ForUnsupportedApiVersion() throws Exception {
+    var getUrl = URL + "/" + USER_ID;
+
+    mockMvc
+        .perform(
+            get(getUrl)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("X-Tenant-Id", TENANT_ID)
+                .header("X-API-Version", "3.0.0"))
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                getUrl,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.INVALID_API_VERSION,
+                "400 BAD_REQUEST \"Invalid API version: '3.0.0'.\"",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(identityService);
   }
 
   @Test
-  void shouldReturn409WhenEmailAlreadyExists() throws Exception {
-    when(identityService.create(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER))
-            .thenThrow(dataIntegrityViolationException("uk_users_tenant_id_email"));
-
-    var userRequest = createUserRequest();
+  void shouldReturnBadRequestWhenApiVersionIsSupportedButNotAcceptedByEndpoint() throws Exception {
+    var getUrl = URL + "/" + USER_ID;
 
     mockMvc
-            .perform(
-                    post(URL)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(JsonUtils.toJson(userRequest))
-                            .header("X-Tenant-Id", TENANT_ID)
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.path").value(URL))
-            .andExpect(jsonPath("$.error").value(HttpStatus.CONFLICT.getReasonPhrase()))
-            .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.DUPLICATE_USER_EMAIL))
-            .andExpect(jsonPath("$.errors[0].message").value("A user with this email already exists."))
-            .andExpect(jsonPath("$.status").value(HttpStatus.CONFLICT.value()));
-  }
+        .perform(
+            get(getUrl)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("X-Tenant-Id", TENANT_ID)
+                .header("X-API-Version", "2.0.0"))
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                getUrl,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.INVALID_API_VERSION,
+                "400 BAD_REQUEST \"Invalid API version: '2.0.0'.\"",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
 
-  @Test
-  void shouldReturn404WhenTenantDoesNotExistDuringUserCreation() throws Exception {
-    when(identityService.create(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER))
-            .thenThrow(dataIntegrityViolationException("fk_users_tenant_id"));
-
-    var userRequest = createUserRequest();
-
-    mockMvc
-            .perform(
-                    post(URL)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(JsonUtils.toJson(userRequest))
-                            .header("X-Tenant-Id", TENANT_ID)
-                            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.path").value(URL))
-            .andExpect(jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
-            .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.TENANT_NOT_FOUND))
-            .andExpect(jsonPath("$.errors[0].message").value("Tenant not found."))
-            .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
+    verifyNoInteractions(identityService);
   }
 
   private ResultMatcher[] validationErrors(
@@ -288,6 +340,25 @@ class IdentityControllerTest {
         Arguments.of(new UserRequest("user@email.com", "1234", null), "role", "must not be null"));
   }
 
+  private static Stream<Arguments> dataIntegrityViolationScenarios() {
+    return Stream.of(
+        Arguments.of(
+            directConstraintViolation("uk_users_tenant_id_email"),
+            HttpStatus.CONFLICT,
+            ApiErrorCodes.DUPLICATE_USER_EMAIL,
+            "A user with this email already exists."),
+        Arguments.of(
+            nestedConstraintViolation("fk_users_tenant_id"),
+            HttpStatus.NOT_FOUND,
+            ApiErrorCodes.TENANT_NOT_FOUND,
+            "Tenant not found."),
+        Arguments.of(
+            withoutConstraintViolation(),
+            HttpStatus.CONFLICT,
+            ApiErrorCodes.DATA_INTEGRITY_VIOLATION,
+            "Data integrity violation."));
+  }
+
   private static UserRequest createUserRequest() {
     return new UserRequest(EMAIL, PASSWORD, UserRole.MEMBER);
   }
@@ -296,10 +367,21 @@ class IdentityControllerTest {
     return new User(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER);
   }
 
-  private static DataIntegrityViolationException dataIntegrityViolationException(
-          String constraintName) {
+  private static DataIntegrityViolationException directConstraintViolation(String constraintName) {
     return new DataIntegrityViolationException(
-            "data integrity violation",
-            new ConstraintViolationException("constraint violation", null, constraintName));
+        "data integrity violation",
+        new ConstraintViolationException("constraint violation", null, constraintName));
+  }
+
+  private static DataIntegrityViolationException nestedConstraintViolation(String constraintName) {
+    var nested = new ConstraintViolationException("constraint violation", null, constraintName);
+
+    return new DataIntegrityViolationException(
+        "data integrity violation", new RuntimeException("wrapper", nested));
+  }
+
+  private static DataIntegrityViolationException withoutConstraintViolation() {
+    return new DataIntegrityViolationException(
+        "data integrity violation", new RuntimeException("wrapper without constraint"));
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
 import br.com.f2e.ovenplatform.tenant.application.TenantService;
 import br.com.f2e.ovenplatform.tenant.domain.Plan;
@@ -31,6 +32,7 @@ class TenantControllerTest {
 
   private static final String URL = "/tenants";
   public static final String TENANT_NAME = "Pizarria bom de garfo";
+
   @Autowired private MockMvc mockMvc;
   @MockitoBean private TenantService tenantService;
 
@@ -38,6 +40,7 @@ class TenantControllerTest {
   void shouldCreateTenantAndReturn201WithLocationAndBody() throws Exception {
     var content = JsonUtils.toJson(new CreateTenantRequest(TENANT_NAME, Plan.MVP));
     when(tenantService.create(TENANT_NAME, Plan.MVP)).thenReturn(getTenant());
+
     mockMvc
         .perform(post(URL).contentType(MediaType.APPLICATION_JSON).content(content))
         .andExpect(status().isCreated())
@@ -51,14 +54,17 @@ class TenantControllerTest {
   @Test
   void shouldReturn400WhenNameIsBlank() throws Exception {
     var content = JsonUtils.toJson(new CreateTenantRequest("", Plan.MVP));
+
     mockMvc
         .perform(post(URL).contentType(MediaType.APPLICATION_JSON).content(content))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.path").value(URL))
         .andExpect(jsonPath("$.error").value(HttpStatus.BAD_REQUEST.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.VALIDATION_ERROR))
         .andExpect(jsonPath("$.errors[0].message").value("must not be blank"))
         .andExpect(jsonPath("$.errors[0].field").value("name"))
         .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()));
+
     verifyNoInteractions(tenantService);
   }
 
@@ -66,6 +72,7 @@ class TenantControllerTest {
   void shouldReturnTenantAnd200WhenTenantExists() throws Exception {
     var tenant = getTenant();
     when(tenantService.findById(tenant.getId())).thenReturn(Optional.of(tenant));
+
     mockMvc
         .perform(get(URL + "/" + tenant.getId()).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
@@ -79,11 +86,13 @@ class TenantControllerTest {
   void shouldReturn404WhenTenantDoesNotExist() throws Exception {
     when(tenantService.findById(getTenant().getId())).thenReturn(Optional.empty());
     var getUrl = URL + "/" + getTenant().getId();
+
     mockMvc
         .perform(get(getUrl).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.path").value(getUrl))
         .andExpect(jsonPath("$.error").value(HttpStatus.NOT_FOUND.getReasonPhrase()))
+        .andExpect(jsonPath("$.errors[0].code").value(ApiErrorCodes.RESOURCE_NOT_FOUND))
         .andExpect(jsonPath("$.status").value(HttpStatus.NOT_FOUND.value()));
   }
 


### PR DESCRIPTION
## Summary
Standardizes the API error contract by introducing stable error codes while keeping human-readable messages in the response.

This PR improves the consistency of API error responses and makes controller tests less fragile by allowing them to assert stable error identifiers instead of relying only on literal messages.

## What changed
- added a stable `code` field to API error items
- introduced centralized public API error code constants
- updated `GlobalExceptionHandler` to return consistent error codes for known scenarios
- kept human-readable error messages in the response as fallback/client-facing text
- refined controller tests to assert stable error fields where useful

## Why
The previous error contract relied too heavily on literal messages, which made tests more brittle and made it harder for clients to depend on stable semantics.

Adding explicit error codes improves:
- API contract stability
- frontend handling of known error scenarios
- observability and debugging
- long-term maintainability of controller tests

## Notes
- this change keeps the current pragmatic exception handling approach
- no large custom exception hierarchy was introduced in this iteration
- `code` is intended to be the stable contract, while `message` remains the human-readable fallback
- architecture and tenant-isolation stories were handled separately

## Validation
- controller tests were updated to reflect the new error contract
- existing error scenarios remain covered
- tests pass locally

Closes #44