### PR TITLE
feat(platform): add request tracing and logging

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
@@ -1,5 +1,7 @@
 package br.com.f2e.ovenplatform.identity.infrastructure.web;
 
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
+
 import br.com.f2e.ovenplatform.identity.application.IdentityService;
 import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserRequest;
 import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserResponse;
@@ -28,7 +30,7 @@ public class IdentityController {
 
   @PostMapping(version = "1.0")
   public ResponseEntity<UserResponse> createUser(
-      @RequestHeader("X-Tenant-Id") UUID tenantId,
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId,
       @Valid @RequestBody UserRequest userRequest,
       HttpServletRequest request) {
     var userResponse =
@@ -44,7 +46,7 @@ public class IdentityController {
 
   @GetMapping(value = "/{id}", version = "1.0")
   public ResponseEntity<UserResponse> findByIdAndTenantId(
-      @RequestHeader("X-Tenant-Id") UUID tenantId, @PathVariable UUID id) {
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId, @PathVariable UUID id) {
     return ResponseEntity.ok(
         UserResponse.fromEntity(identityService.findByIdAndTenantId(id, tenantId)));
   }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/MissingTraceIdException.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/MissingTraceIdException.java
@@ -1,0 +1,8 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.tracing;
+
+public class MissingTraceIdException extends RuntimeException {
+
+  public MissingTraceIdException() {
+    super("Trace ID is not available in the current request context.");
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilter.java
@@ -1,0 +1,42 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.tracing;
+
+import br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+class RequestTracingFilter extends OncePerRequestFilter {
+
+  private final TraceContext traceContext;
+
+  public RequestTracingFilter(TraceContext traceContext) {
+    this.traceContext = traceContext;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    var traceId =
+        Optional.ofNullable(request.getHeader(ApiHeaders.TRACE_ID_HEADER))
+            .filter(s -> !s.isBlank())
+            .orElse(UUID.randomUUID().toString());
+    try {
+      traceContext.setTraceId(traceId);
+      MDC.put(TraceConstants.TRACE_ID_KEY, traceId);
+      response.setHeader(ApiHeaders.TRACE_ID_HEADER, traceId);
+      filterChain.doFilter(request, response);
+    } finally {
+      traceContext.clear();
+      MDC.remove(TraceConstants.TRACE_ID_KEY);
+    }
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilter.java
@@ -8,6 +8,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -15,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 class RequestTracingFilter extends OncePerRequestFilter {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(RequestTracingFilter.class);
   private final TraceContext traceContext;
 
   public RequestTracingFilter(TraceContext traceContext) {
@@ -25,6 +29,7 @@ class RequestTracingFilter extends OncePerRequestFilter {
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
+    var start = System.currentTimeMillis();
     var traceId =
         Optional.ofNullable(request.getHeader(ApiHeaders.TRACE_ID_HEADER))
             .filter(s -> !s.isBlank())
@@ -35,6 +40,13 @@ class RequestTracingFilter extends OncePerRequestFilter {
       response.setHeader(ApiHeaders.TRACE_ID_HEADER, traceId);
       filterChain.doFilter(request, response);
     } finally {
+      var durationMs = System.currentTimeMillis() - start;
+      LOGGER.info(
+          "request completed method={} path={} status={} durationMs={}",
+          request.getMethod(),
+          request.getRequestURI(),
+          response.getStatus(),
+          durationMs);
       traceContext.clear();
       MDC.remove(TraceConstants.TRACE_ID_KEY);
     }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceConstants.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceConstants.java
@@ -1,0 +1,7 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.tracing;
+
+public final class TraceConstants {
+  public static final String TRACE_ID_KEY = "traceId";
+
+  private TraceConstants() {}
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceContext.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceContext.java
@@ -1,0 +1,29 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.tracing;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TraceContext {
+
+  private final ThreadLocal<String> traceIdHolder = new ThreadLocal<>();
+
+  public void setTraceId(String value) {
+    this.traceIdHolder.set(value);
+  }
+
+  public String getTraceId() {
+    if (traceIdHolder.get() == null) {
+      throw new MissingTraceIdException();
+    }
+    return traceIdHolder.get();
+  }
+
+  public Optional<String> findTraceId() {
+    return Optional.ofNullable(traceIdHolder.get());
+  }
+
+  public void clear() {
+    traceIdHolder.remove();
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/ApiHeaders.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/ApiHeaders.java
@@ -1,0 +1,10 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.web;
+
+public final class ApiHeaders {
+
+  public static final String TRACE_ID_HEADER = "X-Trace-Id";
+  public static final String TENANT_ID_HEADER = "X-Tenant-Id";
+  public static final String API_VERSION_HEADER = "X-API-Version";
+
+  private ApiHeaders() {}
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
@@ -5,18 +5,26 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 
 public record ApiErrorResponse(
-    Instant timestamp, int status, String error, List<ApiErrorItem> errors, String path) {
+    Instant timestamp,
+    int status,
+    String error,
+    String traceId,
+    List<ApiErrorItem> errors,
+    String path) {
 
-  public static ApiErrorResponse of(HttpStatus status, List<ApiErrorItem> errors, String path) {
+  public static ApiErrorResponse of(
+      HttpStatus status, String traceId, List<ApiErrorItem> errors, String path) {
     return new ApiErrorResponse(
-        Instant.now(), status.value(), status.getReasonPhrase(), errors, path);
+        Instant.now(), status.value(), status.getReasonPhrase(), traceId, errors, path);
   }
 
-  public static ApiErrorResponse of(HttpStatus status, String code, String message, String path) {
+  public static ApiErrorResponse of(
+      HttpStatus status, String code, String traceId, String message, String path) {
     return new ApiErrorResponse(
         Instant.now(),
         status.value(),
         status.getReasonPhrase(),
+        traceId,
         List.of(ApiErrorItem.messageOnly(code, message)),
         path);
   }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
 
+import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
@@ -20,16 +22,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
   private final MessageSource messageSource;
+  private final TraceContext traceContext;
 
-  public GlobalExceptionHandler(MessageSource messageSource) {
+  public GlobalExceptionHandler(MessageSource messageSource, TraceContext traceContext) {
     this.messageSource = messageSource;
+    this.traceContext = traceContext;
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<ApiErrorResponse> illegalArgumentHandler(
       IllegalArgumentException exception, HttpServletRequest request) {
     return error(
-        HttpStatus.BAD_REQUEST, ApiErrorCodes.INVALID_ARGUMENT, exception.getMessage(), request);
+        HttpStatus.BAD_REQUEST,
+        ApiErrorCodes.INVALID_ARGUMENT,
+        resolveTraceIdForErrorResponse(traceContext),
+        exception.getMessage(),
+        request);
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -43,14 +51,19 @@ public class GlobalExceptionHandler {
                   return ApiErrorItem.of(ApiErrorCodes.VALIDATION_ERROR, error.getField(), message);
                 })
             .toList();
-    return error(HttpStatus.BAD_REQUEST, errors, request);
+    return error(
+        HttpStatus.BAD_REQUEST, resolveTraceIdForErrorResponse(traceContext), errors, request);
   }
 
   @ExceptionHandler(NoSuchElementException.class)
   public ResponseEntity<ApiErrorResponse> notFoundHandler(
       NoSuchElementException exception, HttpServletRequest request) {
     return error(
-        HttpStatus.NOT_FOUND, ApiErrorCodes.RESOURCE_NOT_FOUND, exception.getMessage(), request);
+        HttpStatus.NOT_FOUND,
+        ApiErrorCodes.RESOURCE_NOT_FOUND,
+        resolveTraceIdForErrorResponse(traceContext),
+        exception.getMessage(),
+        request);
   }
 
   @ExceptionHandler(DataIntegrityViolationException.class)
@@ -64,6 +77,7 @@ public class GlobalExceptionHandler {
       MissingRequestHeaderException exception, HttpServletRequest request) {
     return error(
         HttpStatus.BAD_REQUEST,
+        resolveTraceIdForErrorResponse(traceContext),
         ApiErrorCodes.MISSING_REQUEST_HEADER,
         exception.getMessage(),
         request);
@@ -73,14 +87,22 @@ public class GlobalExceptionHandler {
   public ResponseEntity<ApiErrorResponse> invalidApiVersionHandler(
       InvalidApiVersionException exception, HttpServletRequest request) {
     return error(
-        HttpStatus.BAD_REQUEST, ApiErrorCodes.INVALID_API_VERSION, exception.getMessage(), request);
+        HttpStatus.BAD_REQUEST,
+        ApiErrorCodes.INVALID_API_VERSION,
+        resolveTraceIdForErrorResponse(traceContext),
+        exception.getMessage(),
+        request);
   }
 
   @ExceptionHandler(NotAcceptableApiVersionException.class)
   public ResponseEntity<ApiErrorResponse> notAcceptableApiVersionHandler(
       NotAcceptableApiVersionException exception, HttpServletRequest request) {
     return error(
-        HttpStatus.BAD_REQUEST, ApiErrorCodes.INVALID_API_VERSION, exception.getMessage(), request);
+        HttpStatus.BAD_REQUEST,
+        ApiErrorCodes.INVALID_API_VERSION,
+        resolveTraceIdForErrorResponse(traceContext),
+        exception.getMessage(),
+        request);
   }
 
   private String getConstraintName(DataIntegrityViolationException exception) {
@@ -98,15 +120,15 @@ public class GlobalExceptionHandler {
   }
 
   private ResponseEntity<ApiErrorResponse> error(
-      HttpStatus status, String code, String message, HttpServletRequest request) {
+      HttpStatus status, String code, String traceId, String message, HttpServletRequest request) {
     return ResponseEntity.status(status)
-        .body(ApiErrorResponse.of(status, code, message, request.getRequestURI()));
+        .body(ApiErrorResponse.of(status, code, traceId, message, request.getRequestURI()));
   }
 
   private ResponseEntity<ApiErrorResponse> error(
-      HttpStatus status, List<ApiErrorItem> errors, HttpServletRequest request) {
+      HttpStatus status, String traceId, List<ApiErrorItem> errors, HttpServletRequest request) {
     return ResponseEntity.status(status)
-        .body(ApiErrorResponse.of(status, errors, request.getRequestURI()));
+        .body(ApiErrorResponse.of(status, traceId, errors, request.getRequestURI()));
   }
 
   private ResponseEntity<ApiErrorResponse> handleConstraintViolation(
@@ -116,18 +138,29 @@ public class GlobalExceptionHandler {
           error(
               HttpStatus.CONFLICT,
               ApiErrorCodes.DUPLICATE_USER_EMAIL,
+              resolveTraceIdForErrorResponse(traceContext),
               "A user with this email already exists.",
               request);
 
       case "fk_users_tenant_id" ->
-          error(HttpStatus.NOT_FOUND, ApiErrorCodes.TENANT_NOT_FOUND, "Tenant not found.", request);
+          error(
+              HttpStatus.NOT_FOUND,
+              ApiErrorCodes.TENANT_NOT_FOUND,
+              resolveTraceIdForErrorResponse(traceContext),
+              "Tenant not found.",
+              request);
 
       case null, default ->
           error(
               HttpStatus.CONFLICT,
               ApiErrorCodes.DATA_INTEGRITY_VIOLATION,
+              resolveTraceIdForErrorResponse(traceContext),
               "Data integrity violation.",
               request);
     };
+  }
+
+  private String resolveTraceIdForErrorResponse(TraceContext traceContext) {
+    return traceContext.findTraceId().orElse(UUID.randomUUID().toString());
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -77,8 +77,8 @@ public class GlobalExceptionHandler {
       MissingRequestHeaderException exception, HttpServletRequest request) {
     return error(
         HttpStatus.BAD_REQUEST,
-        resolveTraceIdForErrorResponse(traceContext),
         ApiErrorCodes.MISSING_REQUEST_HEADER,
+        resolveTraceIdForErrorResponse(traceContext),
         exception.getMessage(),
         request);
   }

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
@@ -1,5 +1,7 @@
 package br.com.f2e.ovenplatform.identity.infrastructure.web;
 
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.API_VERSION_HEADER;
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -57,7 +59,7 @@ class IdentityControllerTest {
             post(URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(userRequest))
-                .header("X-Tenant-Id", TENANT_ID)
+                .header(TENANT_ID_HEADER, TENANT_ID)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isCreated())
         .andExpect(header().string("Location", containsString(URL)))
@@ -75,7 +77,7 @@ class IdentityControllerTest {
             post(URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(request))
-                .header("X-Tenant-Id", TENANT_ID)
+                .header(TENANT_ID_HEADER, TENANT_ID)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpectAll(
             validationErrors(
@@ -99,7 +101,7 @@ class IdentityControllerTest {
             post(URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(userRequest))
-                .header("X-Tenant-Id", "invalid-uuid"))
+                .header(TENANT_ID_HEADER, "invalid-uuid"))
         .andExpectAll(
             validationErrors(
                 HttpStatus.BAD_REQUEST,
@@ -142,7 +144,7 @@ class IdentityControllerTest {
     mockMvc
         .perform(
             get(URL + "/%s".formatted(USER_ID))
-                .header("X-Tenant-Id", TENANT_ID)
+                .header(TENANT_ID_HEADER, TENANT_ID)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.status").value(UserStatus.ACTIVE.name()))
@@ -161,7 +163,7 @@ class IdentityControllerTest {
         .perform(
             get(getUrl)
                 .contentType(MediaType.APPLICATION_JSON)
-                .header("X-Tenant-Id", TENANT_ID)
+                .header(TENANT_ID_HEADER, TENANT_ID)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpectAll(
             validationErrors(
@@ -199,7 +201,9 @@ class IdentityControllerTest {
 
     mockMvc
         .perform(
-            get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", "invalid tenant"))
+            get(getUrl)
+                .accept(MediaType.APPLICATION_JSON)
+                .header(TENANT_ID_HEADER, "invalid tenant"))
         .andExpectAll(
             validationErrors(
                 HttpStatus.BAD_REQUEST,
@@ -218,7 +222,7 @@ class IdentityControllerTest {
     var getUrl = URL + "/" + "invalidUserId";
 
     mockMvc
-        .perform(get(getUrl).accept(MediaType.APPLICATION_JSON).header("X-Tenant-Id", TENANT_ID))
+        .perform(get(getUrl).accept(MediaType.APPLICATION_JSON).header(TENANT_ID_HEADER, TENANT_ID))
         .andExpectAll(
             validationErrors(
                 HttpStatus.BAD_REQUEST,
@@ -249,7 +253,7 @@ class IdentityControllerTest {
             post(URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(userRequest))
-                .header("X-Tenant-Id", TENANT_ID)
+                .header(TENANT_ID_HEADER, TENANT_ID)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpectAll(
             validationErrors(
@@ -270,8 +274,8 @@ class IdentityControllerTest {
         .perform(
             get(getUrl)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("X-Tenant-Id", TENANT_ID)
-                .header("X-API-Version", "3.0.0"))
+                .header(TENANT_ID_HEADER, TENANT_ID)
+                .header(API_VERSION_HEADER, "3.0.0"))
         .andExpectAll(
             validationErrors(
                 HttpStatus.BAD_REQUEST,
@@ -293,8 +297,8 @@ class IdentityControllerTest {
         .perform(
             get(getUrl)
                 .accept(MediaType.APPLICATION_JSON)
-                .header("X-Tenant-Id", TENANT_ID)
-                .header("X-API-Version", "2.0.0"))
+                .header(TENANT_ID_HEADER, TENANT_ID)
+                .header(API_VERSION_HEADER, "2.0.0"))
         .andExpectAll(
             validationErrors(
                 HttpStatus.BAD_REQUEST,

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
@@ -3,6 +3,7 @@ package br.com.f2e.ovenplatform.identity.infrastructure.web;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.API_VERSION_HEADER;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -16,6 +17,7 @@ import br.com.f2e.ovenplatform.identity.domain.User;
 import br.com.f2e.ovenplatform.identity.domain.UserRole;
 import br.com.f2e.ovenplatform.identity.domain.UserStatus;
 import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserRequest;
+import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
 import java.util.NoSuchElementException;
@@ -28,14 +30,17 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
 
 @WebMvcTest(IdentityController.class)
+@Import(value = {TraceContext.class})
 class IdentityControllerTest {
 
   private static final String EMAIL = "user.email@outlook.com";
@@ -180,18 +185,18 @@ class IdentityControllerTest {
   void shouldReturn400WhenGetTenantIdHeaderIsMissing() throws Exception {
     var getUrl = URL + "/" + USER_ID;
 
-    mockMvc
-        .perform(get(getUrl).accept(MediaType.APPLICATION_JSON))
-        .andExpectAll(
-            validationErrors(
-                HttpStatus.BAD_REQUEST,
-                getUrl,
-                HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                ApiErrorCodes.MISSING_REQUEST_HEADER,
-                "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
-                null,
-                HttpStatus.BAD_REQUEST.value()));
-
+    ResultActions result = mockMvc
+            .perform(get(getUrl).accept(MediaType.APPLICATION_JSON))
+            .andExpectAll(
+                    validationErrors(
+                            HttpStatus.BAD_REQUEST,
+                            getUrl,
+                            HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                            ApiErrorCodes.MISSING_REQUEST_HEADER,
+                            "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
+                            null,
+                            HttpStatus.BAD_REQUEST.value()));
+    assertNotNull(result);
     verifyNoInteractions(identityService);
   }
 
@@ -324,6 +329,7 @@ class IdentityControllerTest {
       status().is(httpStatus.value()),
       jsonPath("$.path").value(path),
       jsonPath("$.error").value(error),
+      jsonPath("$.traceId").isNotEmpty(),
       jsonPath("$.errors[0].code").value(code),
       jsonPath("$.errors[0].message").value(message),
       jsonPath("$.errors[0].field").value(field),

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilterTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilterTest.java
@@ -1,0 +1,102 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.tracing;
+
+import static br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceConstants.TRACE_ID_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestTracingFilterTest {
+
+  private TraceContext traceContext;
+  private RequestTracingFilter filter;
+  private final MockHttpServletRequest request =  new MockHttpServletRequest();
+  private final MockHttpServletResponse response = new MockHttpServletResponse();
+
+  @BeforeEach
+  void setUp() {
+    traceContext = new TraceContext();
+    filter = new RequestTracingFilter(traceContext);
+  }
+
+  @Test
+  void shouldReuseTraceIdFromRequestHeader() throws Exception {
+
+    var traceId = "abc-123";
+    request.addHeader(ApiHeaders.TRACE_ID_HEADER, traceId);
+
+    filter.doFilter(
+        request,
+        response,
+        (_, _) -> {
+          assertEquals(traceId, traceContext.getTraceId());
+          assertEquals(traceId, MDC.get(TRACE_ID_KEY));
+        });
+
+    assertEquals(traceId, response.getHeader(ApiHeaders.TRACE_ID_HEADER));
+    assertTrue(traceContext.findTraceId().isEmpty());
+    assertNull(MDC.get(TRACE_ID_KEY));
+  }
+
+  @Test
+  void shouldGenerateTraceIdWhenHeaderIsMissing() throws ServletException, IOException {
+    var capturedTraceId = new AtomicReference<String>();
+    filter.doFilter(
+        request,
+        response,
+        (_, _) -> {
+          var traceId = traceContext.getTraceId();
+          capturedTraceId.set(traceId);
+
+          assertNotNull(traceId);
+          assertFalse(traceId.isBlank());
+          assertEquals(traceId, MDC.get(TRACE_ID_KEY));
+        });
+
+    var headerTraceId = response.getHeader(ApiHeaders.TRACE_ID_HEADER);
+
+    assertNotNull(headerTraceId);
+    assertFalse(headerTraceId.isBlank());
+    assertEquals(headerTraceId, capturedTraceId.get());
+    assertTrue(traceContext.findTraceId().isEmpty());
+    assertNull(MDC.get(TRACE_ID_KEY));
+  }
+
+  @Test
+  void shouldClearTraceContextAndMdcWhenFilterChainThrowsException() {
+
+    assertThrows(
+        ServletException.class,
+        () ->
+            filter.doFilter(
+                request,
+                response,
+                (_, _) -> {
+                  var traceId = traceContext.getTraceId();
+
+                  assertNotNull(traceId);
+                  assertFalse(traceId.isBlank());
+                  assertEquals(traceId, MDC.get(TRACE_ID_KEY));
+                  throw new ServletException("Exception thrown");
+                }));
+
+    var headerTraceId = response.getHeader(ApiHeaders.TRACE_ID_HEADER);
+
+    assertNotNull(headerTraceId);
+    assertFalse(headerTraceId.isBlank());
+    assertTrue(traceContext.findTraceId().isEmpty());
+    assertNull(MDC.get(TRACE_ID_KEY));
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilterTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilterTest.java
@@ -9,26 +9,43 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.servlet.ServletException;
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 class RequestTracingFilterTest {
 
+  private final MockHttpServletRequest request = new MockHttpServletRequest();
+  private final MockHttpServletResponse response = new MockHttpServletResponse();
+
   private TraceContext traceContext;
   private RequestTracingFilter filter;
-  private final MockHttpServletRequest request =  new MockHttpServletRequest();
-  private final MockHttpServletResponse response = new MockHttpServletResponse();
+  private ListAppender<ILoggingEvent> listAppender;
 
   @BeforeEach
   void setUp() {
     traceContext = new TraceContext();
     filter = new RequestTracingFilter(traceContext);
+
+    request.setMethod(HttpMethod.GET.name());
+    request.setRequestURI("/test");
+
+    Logger logger = (Logger) LoggerFactory.getLogger(RequestTracingFilter.class);
+    listAppender = new ListAppender<>();
+    listAppender.start();
+
+    logger.addAppender(listAppender);
   }
 
   @Test
@@ -37,46 +54,36 @@ class RequestTracingFilterTest {
     var traceId = "abc-123";
     request.addHeader(ApiHeaders.TRACE_ID_HEADER, traceId);
 
-    filter.doFilter(
-        request,
-        response,
-        (_, _) -> {
-          assertEquals(traceId, traceContext.getTraceId());
-          assertEquals(traceId, MDC.get(TRACE_ID_KEY));
-        });
+    filter.doFilter(request, response, (_, _) -> assertTraceIdInContextAndMdc(traceId));
 
     assertEquals(traceId, response.getHeader(ApiHeaders.TRACE_ID_HEADER));
-    assertTrue(traceContext.findTraceId().isEmpty());
-    assertNull(MDC.get(TRACE_ID_KEY));
+    assertTracingContextCleared();
+    assertRequestCompletedLogContains("method=GET", "path=/test", "status=200", "durationMs=");
   }
 
   @Test
-  void shouldGenerateTraceIdWhenHeaderIsMissing() throws ServletException, IOException {
-    var capturedTraceId = new AtomicReference<String>();
+  void shouldGenerateTraceIdWhenHeaderIsMissing() throws Exception {
+    var captured = new AtomicReference<String>();
+
     filter.doFilter(
         request,
         response,
         (_, _) -> {
-          var traceId = traceContext.getTraceId();
-          capturedTraceId.set(traceId);
-
-          assertNotNull(traceId);
-          assertFalse(traceId.isBlank());
-          assertEquals(traceId, MDC.get(TRACE_ID_KEY));
+          var traceId = assertGeneratedTraceIdInContextAndMdc();
+          captured.set(traceId);
         });
 
     var headerTraceId = response.getHeader(ApiHeaders.TRACE_ID_HEADER);
 
     assertNotNull(headerTraceId);
     assertFalse(headerTraceId.isBlank());
-    assertEquals(headerTraceId, capturedTraceId.get());
-    assertTrue(traceContext.findTraceId().isEmpty());
-    assertNull(MDC.get(TRACE_ID_KEY));
+    assertEquals(headerTraceId, captured.get());
+
+    assertTracingContextCleared();
   }
 
   @Test
   void shouldClearTraceContextAndMdcWhenFilterChainThrowsException() {
-
     assertThrows(
         ServletException.class,
         () ->
@@ -84,19 +91,53 @@ class RequestTracingFilterTest {
                 request,
                 response,
                 (_, _) -> {
-                  var traceId = traceContext.getTraceId();
-
-                  assertNotNull(traceId);
-                  assertFalse(traceId.isBlank());
-                  assertEquals(traceId, MDC.get(TRACE_ID_KEY));
+                  assertGeneratedTraceIdInContextAndMdc();
                   throw new ServletException("Exception thrown");
                 }));
 
-    var headerTraceId = response.getHeader(ApiHeaders.TRACE_ID_HEADER);
+    assertTracingContextCleared();
 
-    assertNotNull(headerTraceId);
-    assertFalse(headerTraceId.isBlank());
+    assertRequestCompletedLogContains("method=GET", "path=/test", "status=", "durationMs=");
+  }
+
+  private void assertTracingContextCleared() {
     assertTrue(traceContext.findTraceId().isEmpty());
     assertNull(MDC.get(TRACE_ID_KEY));
+  }
+
+  private String getSingleLogMessage() {
+    assertFalse(listAppender.list.isEmpty());
+    return listAppender.list.getFirst().getFormattedMessage();
+  }
+
+  private void assertRequestCompletedLogContains(String... expectedFragments) {
+    var message = getSingleLogMessage();
+
+    assertTrue(message.contains("request completed"));
+
+    for (var fragment : expectedFragments) {
+      assertTrue(message.contains(fragment));
+    }
+  }
+
+  private void assertTraceIdInContextAndMdc(String expectedTraceId) {
+    assertEquals(expectedTraceId, traceContext.getTraceId());
+    assertEquals(expectedTraceId, MDC.get(TRACE_ID_KEY));
+  }
+
+  private String assertGeneratedTraceIdInContextAndMdc() {
+    var traceId = traceContext.getTraceId();
+
+    assertNotNull(traceId);
+    assertFalse(traceId.isBlank());
+    assertEquals(traceId, MDC.get(TRACE_ID_KEY));
+
+    return traceId;
+  }
+
+  @AfterEach
+  void tearDown() {
+    Logger logger = (Logger) LoggerFactory.getLogger(RequestTracingFilter.class);
+    logger.detachAppender(listAppender);
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceContextTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceContextTest.java
@@ -1,0 +1,51 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.tracing;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TraceContextTest {
+
+  TraceContext traceContext;
+
+  @BeforeEach
+  void setUp() {
+    traceContext = new TraceContext();
+  }
+
+  @Test
+  void shouldStoreAndReturnTraceId() {
+
+    traceContext.setTraceId("trace-id-1777-ewe");
+    assertEquals("trace-id-1777-ewe", traceContext.getTraceId());
+  }
+
+  @Test
+  void shouldFailWhenTraceIdIsNotAvailable() {
+    var exception = assertThrows(MissingTraceIdException.class, () -> traceContext.getTraceId());
+    assertEquals("Trace ID is not available in the current request context.",exception.getMessage());
+  }
+
+  @Test
+  void shouldClearStoredTraceId() {
+    traceContext.setTraceId("trace-id-1777-ewe");
+    traceContext.clear();
+    assertTrue(traceContext.findTraceId().isEmpty());
+  }
+
+  @Test
+  void shouldIsolateTraceIdBetweenThreads() throws Exception {
+    traceContext.setTraceId("trace-id-main-thread");
+    assertEquals("trace-id-main-thread", traceContext.getTraceId());
+
+    try (var executor = Executors.newSingleThreadExecutor()) {
+      var future = executor.submit(traceContext::findTraceId);
+      assertTrue(future.get().isEmpty());
+    }
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,90 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
+
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes.VALIDATION_ERROR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.MessageSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+  private TraceContext traceContext;
+  private GlobalExceptionHandler handler;
+  @Mock private MessageSource messageSource;
+  private MockHttpServletRequest request;
+
+  @BeforeEach
+  void setUp() {
+    traceContext = new TraceContext();
+    handler = new GlobalExceptionHandler(messageSource, traceContext);
+    request = new MockHttpServletRequest();
+  }
+
+  @Test
+  void shouldIncludeTraceIdFromContextInErrorResponse() {
+    traceContext.setTraceId("abc-123");
+    var exception =
+        handler.illegalArgumentHandler(new IllegalArgumentException("exception"), request);
+    var apiErrorResponse = exception.getBody();
+    assertNotNull(apiErrorResponse);
+    assertEquals("abc-123", apiErrorResponse.traceId());
+  }
+
+  @Test
+  void shouldGenerateFallbackTraceIdWhenContextIsEmpty() {
+    var exception =
+        handler.illegalArgumentHandler(new IllegalArgumentException("exception"), request);
+    var apiErrorResponse = exception.getBody();
+    assertNotNull(apiErrorResponse);
+    assertFalse(apiErrorResponse.traceId().isBlank());
+    assertNotNull(apiErrorResponse.traceId());
+  }
+
+  @Test
+  void shouldBuildErrorResponseWithExpectedFields() {
+
+    when(messageSource.getMessage(any(FieldError.class), any()))
+            .thenReturn("invalid field");
+
+    var target = new Object();
+    var objectName = "request";
+    var bindingResult = new BeanPropertyBindingResult(target, objectName);
+
+    bindingResult.addError(new FieldError(objectName, "email", "must not be blank"));
+    bindingResult.addError(new FieldError(objectName, "name", "must not be null"));
+    request.setRequestURI("/test");
+    var exception =
+        handler.badRequestHandler(
+            new MethodArgumentNotValidException(null, bindingResult), request);
+    var apiErrorResponse = exception.getBody();
+    assertNotNull(apiErrorResponse);
+    var errors = apiErrorResponse.errors();
+
+    assertEquals(2, errors.size());
+
+    assertEquals("email", errors.getFirst().field());
+    assertEquals(VALIDATION_ERROR, errors.getFirst().code());
+    assertEquals("invalid field", errors.getFirst().message());
+
+    assertEquals("name", errors.getLast().field());
+    assertEquals(VALIDATION_ERROR, errors.getLast().code());
+    assertEquals("invalid field", errors.getLast().message());
+    assertEquals(400, apiErrorResponse.status());
+    assertNotNull(apiErrorResponse.traceId());
+    assertEquals("/test", apiErrorResponse.path());
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
 import br.com.f2e.ovenplatform.tenant.application.TenantService;
@@ -20,6 +21,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -28,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @ActiveProfiles("test")
 @WebMvcTest(TenantController.class)
+@Import(value = {TraceContext.class})
 class TenantControllerTest {
 
   private static final String URL = "/tenants";


### PR DESCRIPTION
## Summary
Adds lightweight request tracing and logging to improve observability across the application.

This PR introduces a per-request `traceId`, propagates it through the request lifecycle, includes it in API error responses, and adds structured request logging with method, path, status, and duration.

## What changed
- added `TraceContext` to manage request-scoped traceId
- introduced `RequestTracingFilter` to:
  - generate or reuse incoming `traceId`
  - propagate traceId via response header
  - store traceId in MDC during request processing
  - log request completion (method, path, status, duration)
  - ensure proper cleanup of MDC and context
- added `traceId` field to `ApiErrorResponse`
- updated `GlobalExceptionHandler` to include traceId in error responses
- added tests covering:
  - traceId propagation and generation
  - MDC and context cleanup (including exception scenarios)
  - request logging behavior

## Why
This improves debugging and operational visibility by allowing:

- correlation of logs using traceId
- easier investigation of failures and slow requests
- consistent traceability across request lifecycle

It provides a simple observability foundation without introducing full distributed tracing complexity.

## Notes
- implementation is intentionally lightweight (filter + MDC)
- logging uses structured key=value format for easier parsing
- logging is executed in `finally` to cover both success and failure scenarios
- traceId is always cleaned up to avoid cross-request leakage

## Validation
- unit tests cover traceId lifecycle and logging behavior
- exception scenarios validate proper cleanup and logging
- tests pass locally

Closes #48 