### PR TITLE
feat(identity): add JWT generation and validation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,16 @@
         <spring-modulith.version>2.0.3</spring-modulith.version>
         <spotless.version>3.4.0</spotless.version>
         <jacoco.version>0.8.13</jacoco.version>
+        <jjwt.version>0.13.0</jjwt.version>
 
         <sonar.projectKey>Franklin-Barreto_oven-platform</sonar.projectKey>
         <sonar.organization>franklin-barreto</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.coverage.exclusions>**/*OvenPlatformApplication.java,**/*Config.java,**/*Properties.java,**/*Request.java,**/*Response.java,**/ApiErrorResponse.java,**/ApiErrorItem.java</sonar.coverage.exclusions>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.exclusions>
+            **/*OvenPlatformApplication.java,**/*Config.java,**/*Properties.java,**/*Request.java,**/*Response.java,**/ApiErrorResponse.java,**/ApiErrorItem.java
+        </sonar.coverage.exclusions>
     </properties>
     <dependencies>
         <dependency>
@@ -112,8 +116,30 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if Gson is preferred -->
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-crypto</artifactId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/JwtService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/JwtService.java
@@ -1,0 +1,43 @@
+package br.com.f2e.ovenplatform.identity.infrastructure.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+
+  private final SecretKey key;
+  private final long expirationMinutes;
+
+  public JwtService(
+      @Value("${jwt.secret}") String jwtSecret,
+      @Value("${jwt.expiration-minutes}") long expirationMinutes) {
+    key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret));
+    this.expirationMinutes = expirationMinutes;
+  }
+
+  public String generateToken(UUID subject, String roleName) {
+
+    Instant instant = Instant.now();
+    return Jwts.builder()
+        .subject(subject.toString())
+        .issuedAt(new Date(instant.toEpochMilli()))
+        .expiration(new Date(instant.plus(expirationMinutes, ChronoUnit.MINUTES).toEpochMilli()))
+        .signWith(key)
+        .claim("role", roleName)
+        .compact();
+  }
+
+  public Claims parseClaims(String jwt) {
+    return Jwts.parser().verifyWith(key).build().parseSignedClaims(jwt).getPayload();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,9 +7,9 @@ spring:
     init:
       mode: always
   datasource:
-    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB_NAME:oven}
-    username: ${POSTGRES_USER:postgres}
-    password: ${POSTGRES_PASSWORD:postgres}
+    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB_NAME}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 20
@@ -23,3 +23,6 @@ spring:
       supported: 1.0, 2.0
       use:
         header: X-API-Version
+jwt:
+  secret: ${JWT_SECRET}
+  expiration-minutes: ${JWT_EXPIRATION_MINUTES:30}

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/security/JwtServiceTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/security/JwtServiceTest.java
@@ -1,0 +1,63 @@
+package br.com.f2e.ovenplatform.identity.infrastructure.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import br.com.f2e.ovenplatform.identity.domain.UserRole;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoders;
+import java.util.Date;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JwtServiceTest {
+  private static final String TEST_SECRET =
+      Encoders.BASE64.encode(Jwts.SIG.HS256.key().build().getEncoded());
+  private JwtService jwtService;
+  private final UUID subject = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    jwtService = new JwtService(TEST_SECRET, 30);
+  }
+
+  @Test
+  void shouldGenerateAndParseToken() {
+
+    var token = jwtService.generateToken(subject, UserRole.MEMBER.name());
+    var claims = jwtService.parseClaims(token);
+
+    Date issuedAt = claims.getIssuedAt();
+    Date expiration = claims.getExpiration();
+
+    assertEquals(subject, UUID.fromString(claims.getSubject()));
+    assertEquals(UserRole.MEMBER.name(), claims.get("role"));
+    assertNotNull(issuedAt);
+    assertNotNull(expiration);
+    assertTrue(issuedAt.before(expiration));
+  }
+
+  @Test
+  void shouldFailWhenTokenSignatureIsInvalid() {
+
+    var token = jwtService.generateToken(subject, UserRole.MEMBER.name());
+    var jwtServiceWithDifferentSecret =
+        new JwtService(Encoders.BASE64.encode(Jwts.SIG.HS256.key().build().getEncoded()), 20);
+
+    assertThrows(JwtException.class, () -> jwtServiceWithDifferentSecret.parseClaims(token));
+  }
+
+  @Test
+  void shouldFailWhenTokenIsExpired() {
+
+    var expiredJwtService = new JwtService(TEST_SECRET, -1);
+    var token = expiredJwtService.generateToken(subject, UserRole.ADMIN.name());
+
+    assertThrows(ExpiredJwtException.class, () -> expiredJwtService.parseClaims(token));
+  }
+}


### PR DESCRIPTION
PR description
## Summary
Adds JWT generation and validation support to the identity module as the foundation for stateless authentication.

This change introduces the required JWT dependencies, application configuration for token secret and expiration, a `JwtService` responsible for generating signed tokens and validating/parsing token claims, and unit tests covering the main JWT scenarios.

## What changed
- added JJWT dependencies:
  - `jjwt-api`
  - `jjwt-impl`
  - `jjwt-jackson`
- replaced direct `spring-security-crypto` usage with:
  - `spring-boot-starter-security`
  - `spring-security-test`
- added JWT configuration properties in `application.yml`:
  - `jwt.secret`
  - `jwt.expiration-minutes`
- created `JwtService` in `identity.infrastructure.security`
- implemented JWT generation with:
  - `sub` as user id
  - `role` claim
  - issued-at timestamp
  - expiration timestamp
  - HMAC signature using the configured Base64 secret
- implemented JWT parsing and signature validation through signed claims parsing
- added unit tests for `JwtService` covering:
  - successful token generation and parsing
  - invalid signature rejection
  - expired token rejection

## Why
The authentication flow is moving toward stateless JWT-based security.

This change establishes the base support required to:
- issue tokens after successful authentication
- validate signed tokens in future request authentication flow
- keep authentication stateless without relying on server-side session state

## Notes
- token expiration is configurable through application properties
- the current token contract includes `userId` and `role`
- `tenantId` remains in the request header for now and is intentionally not included in the token in this issue
- JWT filter integration is being handled in a separate issue

Closes #11 