### PR TITLE
feat(identity): add JWT authentication filter

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/dto/AuthenticatedUser.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/dto/AuthenticatedUser.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.identity.infrastructure.security.dto;
+
+import br.com.f2e.ovenplatform.identity.domain.UserRole;
+import java.util.UUID;
+
+public record AuthenticatedUser(UUID id, UserRole role) {}

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,88 @@
+package br.com.f2e.ovenplatform.identity.infrastructure.security.filter;
+
+import br.com.f2e.ovenplatform.identity.domain.UserRole;
+import br.com.f2e.ovenplatform.identity.infrastructure.security.JwtService;
+import br.com.f2e.ovenplatform.identity.infrastructure.security.dto.AuthenticatedUser;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+  public static final String BEARER = "Bearer ";
+  private final JwtService jwtService;
+
+  public JwtAuthenticationFilter(JwtService jwtService) {
+    this.jwtService = jwtService;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain)
+      throws ServletException, IOException {
+
+    var authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authHeader == null || !authHeader.startsWith(BEARER)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    var securityContext = SecurityContextHolder.getContext();
+    if (securityContext.getAuthentication() != null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    var token = authHeader.substring(BEARER.length());
+
+    try {
+      Claims claims = jwtService.parseClaims(token);
+      String role = claims.get("role").toString();
+      var authenticatedUser =
+          new AuthenticatedUser(UUID.fromString(claims.getSubject()), UserRole.valueOf(role));
+      var authenticated = getAuthenticated(authenticatedUser, role);
+      securityContext.setAuthentication(authenticated);
+
+    } catch (JwtException ex) {
+      clearContextAndLog("Something wrong while trying to parse the token {}", ex);
+
+    } catch (IllegalArgumentException ex) {
+      clearContextAndLog("User had sent invalid arguments {}", ex);
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private static UsernamePasswordAuthenticationToken getAuthenticated(
+      AuthenticatedUser authenticatedUser, String role) {
+    return new UsernamePasswordAuthenticationToken(
+        authenticatedUser, null, List.of(new SimpleGrantedAuthority(role)));
+  }
+
+  private void clearContextAndLog(String message, Exception ex) {
+    SecurityContextHolder.clearContext();
+    LOGGER.warn(message, ex.getLocalizedMessage(), ex);
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return request.getRequestURI().startsWith("/auth/login");
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityController.java
@@ -4,7 +4,7 @@ import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENAN
 
 import br.com.f2e.ovenplatform.identity.application.IdentityService;
 import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserRequest;
-import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserResponse;
+import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.user.UserResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.UUID;

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/dto/user/UserResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/web/dto/user/UserResponse.java
@@ -1,4 +1,4 @@
-package br.com.f2e.ovenplatform.identity.infrastructure.web.dto;
+package br.com.f2e.ovenplatform.identity.infrastructure.web.dto.user;
 
 import br.com.f2e.ovenplatform.identity.domain.User;
 import br.com.f2e.ovenplatform.identity.domain.UserRole;

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,142 @@
+package br.com.f2e.ovenplatform.identity.infrastructure.security.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import br.com.f2e.ovenplatform.identity.domain.UserRole;
+import br.com.f2e.ovenplatform.identity.infrastructure.security.JwtService;
+import br.com.f2e.ovenplatform.identity.infrastructure.security.dto.AuthenticatedUser;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+  private JwtAuthenticationFilter filter;
+
+  @Mock private JwtService jwtService;
+
+  @Mock private HttpServletRequest request;
+  @Mock private HttpServletResponse response;
+  @Mock private FilterChain filterChain;
+  @Mock Claims claims;
+
+  private final UUID subject = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    SecurityContextHolder.clearContext();
+    filter = new JwtAuthenticationFilter(jwtService);
+    when(request.getRequestURI()).thenReturn("/api/protected");
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void shouldSetAuthenticationWhenBearerTokenIsValid() throws ServletException, IOException {
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer valid-token");
+
+    when(claims.getSubject()).thenReturn(subject.toString());
+    when(claims.get("role")).thenReturn(UserRole.MEMBER.name());
+    when(jwtService.parseClaims("valid-token")).thenReturn(claims);
+
+    filter.doFilter(request, response, filterChain);
+
+    var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    assertNotNull(authentication);
+    assertTrue(authentication.isAuthenticated());
+    assertInstanceOf(AuthenticatedUser.class, authentication.getPrincipal());
+
+    var authenticatedUser = (AuthenticatedUser) authentication.getPrincipal();
+
+    assertEquals(subject, authenticatedUser.id());
+    assertEquals(UserRole.MEMBER, authenticatedUser.role());
+
+    assertTrue(
+        authentication.getAuthorities().stream()
+            .anyMatch(
+                authority -> Objects.equals(authority.getAuthority(), UserRole.MEMBER.name())));
+
+    verify(filterChain).doFilter(request, response);
+    verify(jwtService).parseClaims("valid-token");
+  }
+
+  @Test
+  void shouldNotAuthenticateWhenAuthorizationHeaderIsMissing()
+      throws ServletException, IOException {
+
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(null);
+
+    filter.doFilter(request, response, filterChain);
+
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+
+    verify(filterChain).doFilter(request, response);
+    verifyNoInteractions(jwtService);
+  }
+
+  @Test
+  void shouldNotAuthenticateWhenTokenIsInvalid() throws ServletException, IOException {
+
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer invalid-token");
+    when(jwtService.parseClaims("invalid-token")).thenThrow(new JwtException("Invalid token"));
+
+    filter.doFilter(request, response, filterChain);
+
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+
+    verify(jwtService).parseClaims("invalid-token");
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldNotOverrideExistingAuthentication() throws ServletException, IOException {
+
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer valid-token");
+
+    var role = UserRole.ADMIN;
+    var authenticatedUser = new AuthenticatedUser(subject, role);
+
+    var existingAuthentication =
+        new UsernamePasswordAuthenticationToken(
+            authenticatedUser, null, List.of(new SimpleGrantedAuthority(role.name())));
+
+    SecurityContextHolder.getContext().setAuthentication(existingAuthentication);
+
+    filter.doFilter(request, response, filterChain);
+
+    assertSame(existingAuthentication, SecurityContextHolder.getContext().getAuthentication());
+
+    verifyNoInteractions(jwtService);
+    verify(filterChain).doFilter(request, response);
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
@@ -16,6 +16,7 @@ import br.com.f2e.ovenplatform.identity.application.IdentityService;
 import br.com.f2e.ovenplatform.identity.domain.User;
 import br.com.f2e.ovenplatform.identity.domain.UserRole;
 import br.com.f2e.ovenplatform.identity.domain.UserStatus;
+import br.com.f2e.ovenplatform.identity.infrastructure.security.JwtService;
 import br.com.f2e.ovenplatform.identity.infrastructure.web.dto.UserRequest;
 import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
@@ -51,6 +52,7 @@ class IdentityControllerTest {
 
   @Autowired private MockMvc mockMvc;
   @MockitoBean private IdentityService identityService;
+  @MockitoBean private JwtService jwtService;
 
   @Test
   void shouldCreateUserSuccessfully() throws Exception {
@@ -185,17 +187,18 @@ class IdentityControllerTest {
   void shouldReturn400WhenGetTenantIdHeaderIsMissing() throws Exception {
     var getUrl = URL + "/" + USER_ID;
 
-    ResultActions result = mockMvc
+    ResultActions result =
+        mockMvc
             .perform(get(getUrl).accept(MediaType.APPLICATION_JSON))
             .andExpectAll(
-                    validationErrors(
-                            HttpStatus.BAD_REQUEST,
-                            getUrl,
-                            HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                            ApiErrorCodes.MISSING_REQUEST_HEADER,
-                            "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
-                            null,
-                            HttpStatus.BAD_REQUEST.value()));
+                validationErrors(
+                    HttpStatus.BAD_REQUEST,
+                    getUrl,
+                    HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                    ApiErrorCodes.MISSING_REQUEST_HEADER,
+                    "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
+                    null,
+                    HttpStatus.BAD_REQUEST.value()));
     assertNotNull(result);
     verifyNoInteractions(identityService);
   }

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilterTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/RequestTracingFilterTest.java
@@ -14,7 +14,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import jakarta.servlet.ServletException;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceContextTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/TraceContextTest.java
@@ -1,13 +1,12 @@
 package br.com.f2e.ovenplatform.shared.infrastructure.tracing;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.Executors;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class TraceContextTest {
 
@@ -28,7 +27,8 @@ class TraceContextTest {
   @Test
   void shouldFailWhenTraceIdIsNotAvailable() {
     var exception = assertThrows(MissingTraceIdException.class, () -> traceContext.getTraceId());
-    assertEquals("Trace ID is not available in the current request context.",exception.getMessage());
+    assertEquals(
+        "Trace ID is not available in the current request context.", exception.getMessage());
   }
 
   @Test

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandlerTest.java
@@ -57,8 +57,7 @@ class GlobalExceptionHandlerTest {
   @Test
   void shouldBuildErrorResponseWithExpectedFields() {
 
-    when(messageSource.getMessage(any(FieldError.class), any()))
-            .thenReturn("invalid field");
+    when(messageSource.getMessage(any(FieldError.class), any())).thenReturn("invalid field");
 
     var target = new Object();
     var objectName = "request";

--- a/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import br.com.f2e.ovenplatform.identity.infrastructure.security.JwtService;
 import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
@@ -38,6 +39,7 @@ class TenantControllerTest {
 
   @Autowired private MockMvc mockMvc;
   @MockitoBean private TenantService tenantService;
+  @MockitoBean private JwtService jwtService;
 
   @Test
   void shouldCreateTenantAndReturn201WithLocationAndBody() throws Exception {


### PR DESCRIPTION
## Summary
Adds a JWT authentication filter to the identity module to authenticate requests using bearer tokens.

This change introduces a `OncePerRequestFilter` that extracts JWTs from the `Authorization` header, validates/parses token claims through `JwtService`, builds an authenticated principal from the token claims, and populates the Spring Security context when the token is valid.

## What changed
- added `JwtAuthenticationFilter`
- extracts bearer tokens from the `Authorization` header
- validates and parses JWT claims through `JwtService`
- creates an `AuthenticatedUser` principal using:
  - user id from the token subject
  - role from the token claim
- populates `SecurityContext` with a `UsernamePasswordAuthenticationToken`
- skips JWT authentication for `/auth/login`
- avoids overriding an existing authentication in the security context
- clears the security context when token parsing or claim conversion fails
- added unit tests for the JWT authentication filter covering:
  - valid bearer token authentication
  - missing authorization header
  - invalid token handling
  - existing authentication preservation

## Why
The application is moving toward stateless JWT-based authentication.

This filter connects JWT validation to Spring Security request authentication, allowing protected endpoints to rely on the `SecurityContext` without requiring server-side session state.

## Notes
- invalid or malformed tokens are not authenticated by the filter
- the filter does not directly return a `401`; protected endpoint rejection remains responsibility of Spring Security configuration
- `/auth/login` is intentionally skipped because it is the endpoint responsible for issuing tokens
- `tenantId` remains request-header based for now and is not read from the JWT

Closes #13 