### PR TITLE
chore(platform): add SpotBugs static analysis

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+        <Class name="br.com.f2e.ovenplatform.tenant.domain.Tenant"/>
+    </Match>
+
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+        <Class name="br.com.f2e.ovenplatform.identity.infrastructure.security.config.SecurityConfig"/>
+    </Match>
+
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+        <Class name="br.com.f2e.ovenplatform.shared.infrastructure.web.exception.GlobalExceptionHandler"/>
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,14 @@
                         </format>
                     </formats>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -231,6 +239,30 @@
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>4.0.0.4121</version>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.9.8.3</version>
+                <configuration>
+                    <excludeFilterFile>${project.basedir}/config/spotbugs/exclude.xml</excludeFilterFile>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs</artifactId>
+                        <version>4.9.8</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>check</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/JwtService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/identity/infrastructure/security/JwtService.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
-public class JwtService implements AccessTokenService {
+public final class JwtService implements AccessTokenService {
 
   private final SecretKey key;
   private final long expirationMinutes;

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorResponse.java
@@ -12,6 +12,10 @@ public record ApiErrorResponse(
     List<ApiErrorItem> errors,
     String path) {
 
+  public ApiErrorResponse {
+    errors = List.copyOf(errors);
+  }
+
   public static ApiErrorResponse of(
       HttpStatus status, String traceId, List<ApiErrorItem> errors, String path) {
     return new ApiErrorResponse(


### PR DESCRIPTION
## Summary

Adds SpotBugs static analysis to the Maven build and addresses the initial findings from the first analysis run.

This PR strengthens the project quality gate by introducing automated static analysis, adding a dedicated SpotBugs exclusion filter, and tightening a few implementation details reported by the tool.

## What changed

- added `spotbugs-maven-plugin` to the Maven build
- configured SpotBugs to run during the build lifecycle
- added a dedicated exclusion filter at `config/spotbugs/exclude.xml`
- configured Spotless execution during the Maven lifecycle
- updated `ApiErrorResponse` to defensively copy the `errors` list
- marked `JwtService` as `final`

## Why

The project already has tests, architecture guardrails, formatting, coverage, and Sonar configuration.

Adding SpotBugs improves the quality foundation by detecting potential bad practices and risky implementation patterns earlier, before they reach main.

## Notes

- domain constructors continue to enforce invariants by throwing exceptions when invalid state is provided
- intentional domain validation should not be weakened to satisfy static analysis
- SpotBugs exclusions should remain targeted and justified
- `ApiErrorResponse` keeps the same public contract
- this PR does not change authentication behavior

## Validation

- [X] tests pass locally
- [X] SpotBugs check passes locally
- [X] Spotless runs successfully
- [X] Maven build completes successfully

Closes #54