### PR TITLE
feat(catalog): add list products API

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/web/ProductController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/web/ProductController.java
@@ -5,8 +5,10 @@ import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENAN
 import br.com.f2e.ovenplatform.catalog.application.CatalogService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -37,5 +39,14 @@ public class ProductController {
             .buildAndExpand(productResponse.id())
             .toUri();
     return ResponseEntity.created(uri).body(productResponse);
+  }
+
+  @GetMapping(version = "1.0")
+  public ResponseEntity<List<ProductResponse>> list(
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId) {
+    var products =
+        service.listActiveProducts(tenantId).stream().map(ProductResponse::from).toList();
+
+    return ResponseEntity.ok(products);
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/catalog/infrastructure/web/ProductControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/catalog/infrastructure/web/ProductControllerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -17,6 +18,7 @@ import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -116,6 +118,76 @@ class ProductControllerTest {
             post(BASE_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtils.toJson(createProductRequest()))
+                .header(TENANT_ID_HEADER, "invalid-uuid"))
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                BASE_URL,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.INVALID_ARGUMENT,
+                "Invalid UUID string: invalid-uuid",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(catalogService);
+  }
+
+  @Test
+  void shouldListActiveProducts() throws Exception {
+    var product = new Product(TENANT_ID, VALID_PRODUCT, VALID_PRICE);
+
+    when(catalogService.listActiveProducts(TENANT_ID)).thenReturn(List.of(product));
+
+    mockMvc
+        .perform(
+            get(BASE_URL).header(TENANT_ID_HEADER, TENANT_ID).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$[0].tenantId").value(TENANT_ID.toString()))
+        .andExpect(jsonPath("$[0].name").value(VALID_PRODUCT))
+        .andExpect(jsonPath("$[0].price").value(10.5))
+        .andExpect(jsonPath("$[0].active").value(true));
+
+    verify(catalogService).listActiveProducts(TENANT_ID);
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoActiveProductsExist() throws Exception {
+    when(catalogService.listActiveProducts(TENANT_ID)).thenReturn(List.of());
+
+    mockMvc
+        .perform(
+            get(BASE_URL).header(TENANT_ID_HEADER, TENANT_ID).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+
+    verify(catalogService).listActiveProducts(TENANT_ID);
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenListTenantHeaderIsMissing() throws Exception {
+    mockMvc
+        .perform(get(BASE_URL).accept(MediaType.APPLICATION_JSON))
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                BASE_URL,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.MISSING_REQUEST_HEADER,
+                "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(catalogService);
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenListTenantHeaderIsInvalid() throws Exception {
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .accept(MediaType.APPLICATION_JSON)
                 .header(TENANT_ID_HEADER, "invalid-uuid"))
         .andExpectAll(
             validationErrors(


### PR DESCRIPTION
## Summary

Adds the `GET /products` API endpoint to the Catalog module.

This PR exposes the active product listing flow through the web layer, reusing the existing Catalog application service and product response mapping.

## What changed

- added `GET /products`
- reads tenant context from `X-Tenant-Id`
- delegates product listing to `CatalogService`
- returns only active products for the provided tenant
- maps products to `ProductResponse`
- returns `200 OK` with a product response list
- returns an empty list when no active products exist
- added WebMvc tests for successful product listing
- added WebMvc tests for empty product listing
- added WebMvc tests for missing and invalid tenant header scenarios
- verified the controller delegates product listing to `CatalogService`
- verified tenant header errors do not call `CatalogService`

## Why

The Catalog module already supports product creation through the API.

This PR completes the first Catalog read flow by allowing tenant users to list active products available in their catalog.

This prepares the platform for future order creation flows, where users will need to select products from the tenant catalog.

## Notes

- Tenant context continues to come from `X-Tenant-Id`
- Moving tenant context into JWT is intentionally out of scope
- Pagination, sorting, and filtering are intentionally out of scope for this iteration
- Inactive products are not returned by this endpoint
- Controller tests remain focused on MVC behavior, response mapping, header validation, and delegation
- Security integration for protected endpoints should remain in a dedicated security test scope

## Validation

- [x] added WebMvc test for successful product listing
- [x] added WebMvc test for empty product listing
- [x] added WebMvc tests for tenant header errors
- [x] verified `CatalogService` is called with the expected tenant id
- [x] verified invalid tenant header requests do not call `CatalogService`
- [x] full test suite passes locally
- [x] SpotBugs passes locally
- [x] architecture tests pass locally

Closes #17