### PR TITLE
feat(orders): add order aggregate with items

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/catalog/domain/Product.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/domain/Product.java
@@ -21,7 +21,7 @@ public class Product extends BaseEntity {
   @Column(nullable = false, length = 80)
   private String name;
 
-  @Column(nullable = false, precision = 10, scale = 2)
+  @Column(nullable = false, precision = 19, scale = 2)
   private BigDecimal price;
 
   @Column(nullable = false)

--- a/src/main/java/br/com/f2e/ovenplatform/orders/domain/Order.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/domain/Order.java
@@ -1,0 +1,70 @@
+package br.com.f2e.ovenplatform.orders.domain;
+
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requireNotNull;
+
+import br.com.f2e.ovenplatform.shared.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "orders")
+public class Order extends BaseEntity {
+
+  @Column(nullable = false)
+  private UUID tenantId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 30)
+  private OrderStatus status;
+
+  @Column(nullable = false, precision = 19, scale = 2)
+  private BigDecimal totalAmount;
+
+  @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+  private final List<OrderItem> items = new ArrayList<>();
+
+  @SuppressWarnings("unused")
+  protected Order() {}
+
+  public Order(UUID tenantId) {
+    this.tenantId = requireNotNull(tenantId, "tenantId");
+    this.status = OrderStatus.CREATED;
+    this.totalAmount = BigDecimal.ZERO;
+  }
+
+  public UUID getTenantId() {
+    return tenantId;
+  }
+
+  public BigDecimal getTotalAmount() {
+    return totalAmount;
+  }
+
+  public void addItem(UUID productId, int quantity, BigDecimal unitPrice) {
+    var item = new OrderItem(this, productId, quantity, unitPrice);
+    items.add(item);
+    recalculateTotal();
+  }
+
+  public List<OrderItem> getItems() {
+    return List.copyOf(items);
+  }
+
+  private void recalculateTotal() {
+    this.totalAmount =
+        items.stream().map(OrderItem::getSubtotal).reduce(BigDecimal.ZERO, BigDecimal::add);
+  }
+
+  public OrderStatus getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/domain/OrderItem.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/domain/OrderItem.java
@@ -1,0 +1,62 @@
+package br.com.f2e.ovenplatform.orders.domain;
+
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requireNotNull;
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requirePositive;
+
+import br.com.f2e.ovenplatform.shared.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "order_items")
+public class OrderItem extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "order_id", nullable = false)
+  private Order order;
+
+  @Column(nullable = false)
+  private UUID productId;
+
+  @Column(nullable = false)
+  private int quantity;
+
+  @Column(nullable = false, precision = 19, scale = 2)
+  private BigDecimal unitPrice;
+
+  @Column(nullable = false, precision = 19, scale = 2)
+  private BigDecimal subtotal;
+
+  @SuppressWarnings("unused")
+  protected OrderItem() {}
+
+  OrderItem(Order order, UUID productId, int quantity, BigDecimal unitPrice) {
+    this.order = requireNotNull(order, "order");
+    this.productId = requireNotNull(productId, "productId");
+    this.quantity = requirePositive(quantity, "quantity");
+    this.unitPrice = requirePositive(unitPrice, "unitPrice");
+    this.subtotal = this.unitPrice.multiply(BigDecimal.valueOf(this.quantity));
+  }
+
+  public UUID getProductId() {
+    return productId;
+  }
+
+  public int getQuantity() {
+    return quantity;
+  }
+
+  public BigDecimal getUnitPrice() {
+    return unitPrice;
+  }
+
+  public BigDecimal getSubtotal() {
+    return subtotal;
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/domain/OrderStatus.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/domain/OrderStatus.java
@@ -1,0 +1,5 @@
+package br.com.f2e.ovenplatform.orders.domain;
+
+public enum OrderStatus {
+  CREATED
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/domain/validation/Preconditions.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/domain/validation/Preconditions.java
@@ -35,6 +35,14 @@ public final class Preconditions {
     return field;
   }
 
+  public static int requirePositive(int field, String fieldName) {
+    if (field <= 0) {
+      throw new IllegalArgumentException("%s must be greater than zero".formatted(fieldName));
+    }
+
+    return field;
+  }
+
   public static String requireMinimumSize(String field, String fieldName, int minimumSize) {
     var trimmed = requireNotBlank(field, fieldName);
 

--- a/src/main/resources/db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="004-create-orders-and-order-items-tables" author="franklin">
+        <createTable tableName="orders">
+            <column name="id" type="uuid">
+                <constraints primaryKey="true" primaryKeyName="pk_orders" nullable="false"/>
+            </column>
+
+            <column name="tenant_id" type="uuid">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="status" type="varchar(30)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="total_amount" type="numeric(19,2)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at" type="timestamp">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="updated_at" type="timestamp">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="order_items">
+            <column name="id" type="uuid">
+                <constraints primaryKey="true" primaryKeyName="pk_order_items" nullable="false"/>
+            </column>
+
+            <column name="order_id" type="uuid">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="product_id" type="uuid">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="quantity" type="int">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="unit_price" type="numeric(19,2)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="subtotal" type="numeric(19,2)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at" type="timestamp">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="updated_at" type="timestamp">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="orders"
+                baseColumnNames="tenant_id"
+                constraintName="fk_orders_tenant_id"
+                referencedTableName="tenants"
+                referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+                baseTableName="order_items"
+                baseColumnNames="order_id"
+                constraintName="fk_order_items_order_id"
+                referencedTableName="orders"
+                referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint
+                baseTableName="order_items"
+                baseColumnNames="product_id"
+                constraintName="fk_order_items_product_id"
+                referencedTableName="products"
+                referencedColumnNames="id"/>
+
+        <createIndex indexName="idx_orders_tenant_id" tableName="orders">
+            <column name="tenant_id"/>
+        </createIndex>
+
+        <createIndex indexName="idx_orders_tenant_id_status" tableName="orders">
+            <column name="tenant_id"/>
+            <column name="status"/>
+        </createIndex>
+
+        <createIndex indexName="idx_order_items_order_id" tableName="order_items">
+            <column name="order_id"/>
+        </createIndex>
+
+        <createIndex indexName="idx_order_items_product_id" tableName="order_items">
+            <column name="product_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -9,5 +9,6 @@
     <include file="db/changelog/changes/db.changelog-001-create-tenants.xml"/>
     <include file="db/changelog/changes/db.changelog-002create-users.xml"/>
     <include file="db/changelog/changes/db.changelog-003create-products.xml"/>
+    <include file="db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/br/com/f2e/ovenplatform/orders/domain/OrderTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/domain/OrderTest.java
@@ -1,0 +1,110 @@
+package br.com.f2e.ovenplatform.orders.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class OrderTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
+  private static final UUID PRODUCT_ID = UUID.fromString("b5b6c3d2-3f69-45c5-8a4b-8d6d8a9c1234");
+  private static final int VALID_QUANTITY = 2;
+  private static final BigDecimal VALID_UNIT_PRICE = new BigDecimal("35.40");
+
+  @Test
+  void shouldCreateOrderWithInitialState() {
+
+    assertThat(order().getTenantId()).isEqualTo(TENANT_ID);
+    assertThat(order().getStatus()).isEqualTo(OrderStatus.CREATED);
+    assertThat(order().getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    assertThat(order().getItems()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectNullTenantId() {
+    assertThatThrownBy(() -> new Order(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tenantId must not be null");
+  }
+
+  @Test
+  void shouldAddItemToOrder() {
+    var order = order();
+
+    order.addItem(PRODUCT_ID, VALID_QUANTITY, VALID_UNIT_PRICE);
+
+    assertThat(order.getItems()).hasSize(1);
+
+    var item = order.getItems().getFirst();
+
+    assertThat(item.getQuantity()).isEqualTo(VALID_QUANTITY);
+    assertThat(item.getProductId()).isEqualTo(PRODUCT_ID);
+    assertThat(item.getUnitPrice()).isEqualByComparingTo(VALID_UNIT_PRICE);
+    assertThat(item.getSubtotal()).isEqualByComparingTo("70.80");
+  }
+
+  @Test
+  void shouldRecalculateTotalWhenAddingOneItem() {
+    var order = order();
+
+    order.addItem(PRODUCT_ID, VALID_QUANTITY, VALID_UNIT_PRICE);
+
+    assertThat(order.getTotalAmount()).isEqualByComparingTo("70.80");
+  }
+
+  @Test
+  void shouldRecalculateTotalWhenAddingMultipleItems() {
+    var order = order();
+
+    order.addItem(PRODUCT_ID, 2, new BigDecimal("35.40"));
+    order.addItem(UUID.randomUUID(), 3, new BigDecimal("10.00"));
+
+    assertThat(order.getTotalAmount()).isEqualByComparingTo("100.80");
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidItems")
+  void shouldRejectInvalidItemData(
+      UUID productId, int quantity, BigDecimal unitPrice, String expectedMessage) {
+    var order = new Order(TENANT_ID);
+    assertThatThrownBy(() -> order.addItem(productId, quantity, unitPrice))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(expectedMessage);
+  }
+
+  @Test
+  void shouldExposeItemsAsReadOnlyCollection() {
+    var order = order();
+    order.addItem(PRODUCT_ID, VALID_QUANTITY, VALID_UNIT_PRICE);
+
+    var items = order.getItems();
+
+    assertThatThrownBy(items::clear).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  private static Stream<Arguments> invalidItems() {
+    return Stream.of(
+        Arguments.of(null, VALID_QUANTITY, VALID_UNIT_PRICE, "productId must not be null"),
+        Arguments.of(PRODUCT_ID, 0, VALID_UNIT_PRICE, "quantity must be greater than zero"),
+        Arguments.of(PRODUCT_ID, -1, VALID_UNIT_PRICE, "quantity must be greater than zero"),
+        Arguments.of(PRODUCT_ID, VALID_QUANTITY, null, "unitPrice must not be null"),
+        Arguments.of(
+            PRODUCT_ID, VALID_QUANTITY, BigDecimal.ZERO, "unitPrice must be greater than zero"),
+        Arguments.of(
+            PRODUCT_ID,
+            VALID_QUANTITY,
+            new BigDecimal("-1.00"),
+            "unitPrice must be greater than zero"));
+  }
+
+  private static Order order() {
+    return new Order(TENANT_ID);
+  }
+}


### PR DESCRIPTION
## Summary

Adds the initial Order aggregate to the Orders module.

This PR introduces the Order aggregate root and its owned OrderItem entities, including domain behavior, invariants, JPA mappings, and Liquibase migration.

## What changed

- added `Order` aggregate root
- added `OrderItem` entity owned by `Order`
- added `OrderStatus` enum with initial `CREATED` state
- implemented item management behavior in `Order`
- implemented total amount recalculation based on item subtotals
- enforced domain invariants for order creation and item addition
- added shared validation support for numeric fields (`requirePositive` overloads)
- added JPA mappings for `Order` and `OrderItem`
- added Liquibase migration for `orders` and `order_items` tables
- added foreign key constraints:
  - `orders.tenant_id -> tenants.id`
  - `order_items.order_id -> orders.id`
  - `order_items.product_id -> products.id`
- added indexes for tenant and relationship access patterns
- updated monetary precision to `numeric(19,2)` for consistency across domain
- added unit tests covering:
  - order initial state
  - item addition
  - total calculation (single and multiple items)
  - invalid item data
  - read-only item collection

## Why

Orders are the core business concept of the platform.

This PR establishes a rich domain model with proper aggregate boundaries and invariants, providing a solid foundation for future features such as:

- order persistence and queries
- order APIs
- status transitions
- events and outbox pattern
- retry and idempotency

## Notes

- `Order` is the aggregate root and owns `OrderItem`
- `OrderItem` is modeled as a JPA entity with a technical identifier but remains controlled by the aggregate
- no repository, application service, or API endpoints were introduced in this PR
- product lookup and validation are intentionally out of scope
- status transitions beyond `CREATED` are intentionally out of scope
- domain model follows a pragmatic approach combining rich domain behavior with JPA annotations

## Validation

- [x] domain invariants enforced through constructors and behavior
- [x] unit tests cover aggregate behavior and edge cases
- [x] Liquibase migration aligned with JPA mappings
- [x] foreign keys and indexes defined
- [x] full test suite passes locally
- [x] SpotBugs passes locally
- [x] architecture tests pass locally

Closes #18