### PR TITLE
feat(orders): add persistence and application service

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/persistence/SpringDataProductRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/persistence/SpringDataProductRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-interface SpringDataProductRepository extends JpaRepository<Product, UUID> {
+public interface SpringDataProductRepository extends JpaRepository<Product, UUID> {
   Optional<Product> findByIdAndTenantId(UUID id, UUID tenantId);
 
   List<Product> findByTenantIdAndActiveTrue(UUID tenantId);

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderRepository.java
@@ -1,0 +1,16 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import br.com.f2e.ovenplatform.orders.domain.Order;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrderRepository {
+  Order save(Order order);
+
+  Optional<Order> findByIdAndTenantId(UUID id, UUID tenantId);
+
+  Optional<Order> findByIdAndTenantIdWithItems(UUID id, UUID tenantId);
+
+  List<Order> findByTenantId(UUID tenantId);
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
@@ -1,0 +1,37 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import br.com.f2e.ovenplatform.orders.domain.Order;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderService {
+
+  private final OrderRepository orderRepository;
+
+  public OrderService(OrderRepository orderRepository) {
+    this.orderRepository = orderRepository;
+  }
+
+  public Order save(Order order) {
+    return orderRepository.save(order);
+  }
+
+  public Order createOrder(UUID tenantId) {
+    return orderRepository.save(new Order(tenantId));
+  }
+
+  public Optional<Order> findOrder(UUID tenantId, UUID orderId) {
+    return orderRepository.findByIdAndTenantId(orderId, tenantId);
+  }
+
+  public Optional<Order> findOrderWithItems(UUID tenantId, UUID orderId) {
+    return orderRepository.findByIdAndTenantIdWithItems(orderId, tenantId);
+  }
+
+  public List<Order> listOrders(UUID tenantId) {
+    return orderRepository.findByTenantId(tenantId);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/persistence/JpaOrderRepositoryAdapter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/persistence/JpaOrderRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.persistence;
+
+import br.com.f2e.ovenplatform.orders.application.OrderRepository;
+import br.com.f2e.ovenplatform.orders.domain.Order;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaOrderRepositoryAdapter implements OrderRepository {
+
+  private final SpringDataOrderRepository orderRepository;
+
+  public JpaOrderRepositoryAdapter(SpringDataOrderRepository orderRepository) {
+    this.orderRepository = orderRepository;
+  }
+
+  @Override
+  public Order save(Order order) {
+    return orderRepository.save(order);
+  }
+
+  @Override
+  public Optional<Order> findByIdAndTenantId(UUID id, UUID tenantId) {
+    return orderRepository.findByIdAndTenantId(id, tenantId);
+  }
+
+  @Override
+  public Optional<Order> findByIdAndTenantIdWithItems(UUID id, UUID tenantId) {
+    return orderRepository.findByIdAndTenantIdWithItems(id, tenantId);
+  }
+
+  @Override
+  public List<Order> findByTenantId(UUID tenantId) {
+    return orderRepository.findByTenantId(tenantId);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/persistence/SpringDataOrderRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/persistence/SpringDataOrderRepository.java
@@ -1,0 +1,25 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.persistence;
+
+import br.com.f2e.ovenplatform.orders.domain.Order;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface SpringDataOrderRepository extends JpaRepository<Order, UUID> {
+
+  Optional<Order> findByIdAndTenantId(UUID id, UUID tenantId);
+
+  List<Order> findByTenantId(UUID tenantId);
+
+  @Query(
+      """
+      select o
+      from Order o
+      left join fetch o.items
+      where o.id = :id
+        and o.tenantId = :tenantId
+      """)
+  Optional<Order> findByIdAndTenantIdWithItems(UUID id, UUID tenantId);
+}

--- a/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
@@ -1,0 +1,165 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import br.com.f2e.ovenplatform.catalog.domain.Product;
+import br.com.f2e.ovenplatform.catalog.infrastructure.persistence.SpringDataProductRepository;
+import br.com.f2e.ovenplatform.orders.domain.Order;
+import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
+import br.com.f2e.ovenplatform.orders.infrastructure.persistence.JpaOrderRepositoryAdapter;
+import br.com.f2e.ovenplatform.tenant.domain.Plan;
+import br.com.f2e.ovenplatform.tenant.domain.Tenant;
+import br.com.f2e.ovenplatform.tenant.infrastructure.persistence.SpringDataTenantRepository;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({OrderService.class, JpaOrderRepositoryAdapter.class})
+@EnableJpaAuditing
+class OrderServiceIntegrationTest {
+
+  private static final BigDecimal UNIT_PRICE = new BigDecimal("35.40");
+
+  @Autowired private OrderService orderService;
+  @Autowired private SpringDataTenantRepository tenantRepository;
+  @Autowired private SpringDataProductRepository productRepository;
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  void shouldCreateOrder() {
+
+    var tenant = createTenant();
+    var order = orderService.createOrder(tenant.getId());
+
+    assertThat(order.getTenantId()).isEqualTo(tenant.getId());
+    assertThat(order.getId()).isNotNull();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.CREATED);
+    assertThat(order.getItems()).isEmpty();
+  }
+
+  @Test
+  void shouldSaveAndFindOrderWithItems() {
+    var tenant = createTenant();
+    var product = createProduct(tenant);
+
+    var order = new Order(tenant.getId());
+    var quantity = 2;
+
+    order.addItem(product.getId(), quantity, UNIT_PRICE);
+
+    var savedOrder = orderService.save(order);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var foundOrder = orderService.findOrderWithItems(tenant.getId(), savedOrder.getId());
+
+    assertThat(foundOrder).isPresent();
+
+    var persistedOrder = foundOrder.get();
+
+    var expectedPrice = "70.80";
+
+    assertThat(persistedOrder.getStatus()).isEqualTo(OrderStatus.CREATED);
+    assertThat(persistedOrder.getTotalAmount()).isEqualByComparingTo(expectedPrice);
+    assertThat(persistedOrder.getItems()).hasSize(1);
+
+    var item = persistedOrder.getItems().getFirst();
+
+    assertThat(item.getProductId()).isEqualTo(product.getId());
+    assertThat(item.getQuantity()).isEqualTo(quantity);
+    assertThat(item.getUnitPrice()).isEqualByComparingTo(UNIT_PRICE);
+    assertThat(item.getSubtotal()).isEqualByComparingTo(expectedPrice);
+  }
+
+  @Test
+  void shouldFindOrderByIdAndTenantId() {
+    var tenant = createTenant();
+    var savedOrder = orderService.createOrder(tenant.getId());
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var foundOrder = orderService.findOrder(tenant.getId(), savedOrder.getId());
+
+    assertThat(foundOrder)
+        .isPresent()
+        .get()
+        .satisfies(
+            order -> {
+              assertThat(order.getId()).isEqualTo(savedOrder.getId());
+              assertThat(order.getTenantId()).isEqualTo(tenant.getId());
+              assertThat(order.getStatus()).isEqualTo(OrderStatus.CREATED);
+              assertThat(order.getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+            });
+  }
+
+  @Test
+  void shouldReturnEmptyWhenOrderDoesNotExist() {
+
+    var tenant = createTenant();
+    var unknownOrderId = UUID.randomUUID();
+
+    var order = orderService.findOrder(tenant.getId(), unknownOrderId);
+
+    assertThat(order).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenOrderBelongsToAnotherTenant() {
+    var tenant = createTenant();
+    var anotherTenant = createTenant("Soprano Pizzeria");
+    var order = orderService.createOrder(tenant.getId());
+
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(orderService.findOrder(anotherTenant.getId(), order.getId())).isEmpty();
+  }
+
+  @Test
+  void shouldListOrdersByTenant() {
+
+    UUID tenantId = createTenant().getId();
+    orderService.createOrder(tenantId);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var orders = orderService.listOrders(tenantId);
+
+    assertThat(orders).hasSize(1).extracting(Order::getTenantId).containsOnly(tenantId);
+  }
+
+  @Test
+  void shouldNotListOrdersFromAnotherTenant() {
+
+    UUID tenantId = createTenant().getId();
+    orderService.createOrder(tenantId);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(orderService.listOrders(createTenant("La mama").getId())).isEmpty();
+  }
+
+  private Tenant createTenant() {
+    return createTenant("Don Corleone Pizzeria");
+  }
+
+  private Tenant createTenant(String name) {
+    return tenantRepository.save(new Tenant(name, Plan.MVP));
+  }
+
+  private Product createProduct(Tenant tenant) {
+    return productRepository.save(new Product(tenant.getId(), "Pizza portuguesa", UNIT_PRICE));
+  }
+}


### PR DESCRIPTION
## Summary

Adds persistence and application service layer for the Orders module.

This PR introduces the OrderRepository port, Spring Data repository, JPA adapter, and OrderService, enabling tenant-scoped order persistence and retrieval.

## What changed

- added `OrderRepository` port in application layer
- added `SpringDataOrderRepository` in infrastructure
- added `JpaOrderRepositoryAdapter` to isolate Spring Data
- added `OrderService` as application entry point
- implemented tenant-scoped persistence:
  - save order
  - save order with items
  - find order by id and tenant
  - find order with items
  - list orders by tenant
- added integration tests covering:
  - order creation
  - saving order with items
  - finding order by tenant
  - tenant isolation (by id and list)
  - retrieving order with items

## Why

This PR connects the Orders domain to the persistence layer while keeping infrastructure concerns isolated.

It enables:

- aggregate persistence validation (Order + OrderItem)
- tenant-scoped queries
- foundation for upcoming features such as API, events, and status transitions

## Notes

- `Order` remains the aggregate root and owns `OrderItem`
- `OrderItem` is persisted via cascade through the aggregate
- repository access is fully encapsulated behind the application port
- queries explicitly support loading items only when needed to avoid unnecessary fetching
- tests use real JPA behavior with `flush` and `clear` to validate persistence correctly

## Validation

- [x] aggregate persistence works with items
- [x] tenant isolation is enforced in all queries
- [x] integration tests cover main use cases
- [x] no direct use of Spring Data outside infrastructure
- [x] SpotBugs passes
- [x] architecture tests pass

Closes #19