### PR TITLE
feat(catalog): add sellable product lookup

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/catalog/application/CatalogProductLookupService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/application/CatalogProductLookupService.java
@@ -1,0 +1,26 @@
+package br.com.f2e.ovenplatform.catalog.application;
+
+import br.com.f2e.ovenplatform.catalog.application.api.CatalogProductLookup;
+import br.com.f2e.ovenplatform.catalog.application.api.SellableProduct;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CatalogProductLookupService implements CatalogProductLookup {
+
+  private final ProductRepository repository;
+
+  public CatalogProductLookupService(ProductRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public List<SellableProduct> findSellableProducts(UUID tenantId, Set<UUID> productIds) {
+
+    return repository.findActiveByTenantIdAndIdIn(tenantId, productIds).stream()
+        .map(product -> new SellableProduct(product.getId(), product.getPrice()))
+        .toList();
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/catalog/application/ProductRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/application/ProductRepository.java
@@ -3,6 +3,7 @@ package br.com.f2e.ovenplatform.catalog.application;
 import br.com.f2e.ovenplatform.catalog.domain.Product;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface ProductRepository {
@@ -11,4 +12,6 @@ public interface ProductRepository {
   Optional<Product> findByIdAndTenantId(UUID id, UUID tenantId);
 
   List<Product> findActiveByTenantId(UUID tenantId);
+
+  List<Product> findActiveByTenantIdAndIdIn(UUID tenantId, Set<UUID> productIds);
 }

--- a/src/main/java/br/com/f2e/ovenplatform/catalog/application/api/CatalogProductLookup.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/application/api/CatalogProductLookup.java
@@ -1,0 +1,10 @@
+package br.com.f2e.ovenplatform.catalog.application.api;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public interface CatalogProductLookup {
+
+  List<SellableProduct> findSellableProducts(UUID tenantId, Set<UUID> productIds);
+}

--- a/src/main/java/br/com/f2e/ovenplatform/catalog/application/api/SellableProduct.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/application/api/SellableProduct.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.catalog.application.api;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record SellableProduct(UUID productId, BigDecimal price) {}

--- a/src/main/java/br/com/f2e/ovenplatform/catalog/application/api/package-info.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/application/api/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("api")
+package br.com.f2e.ovenplatform.catalog.application.api;

--- a/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/persistence/JpaProductRepositoryAdapter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/persistence/JpaProductRepositoryAdapter.java
@@ -4,6 +4,7 @@ import br.com.f2e.ovenplatform.catalog.application.ProductRepository;
 import br.com.f2e.ovenplatform.catalog.domain.Product;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
@@ -29,5 +30,10 @@ public class JpaProductRepositoryAdapter implements ProductRepository {
   @Override
   public List<Product> findActiveByTenantId(UUID tenantId) {
     return repository.findByTenantIdAndActiveTrue(tenantId);
+  }
+
+  @Override
+  public List<Product> findActiveByTenantIdAndIdIn(UUID tenantId, Set<UUID> productIds) {
+    return repository.findByTenantIdAndIdInAndActiveTrue(tenantId, productIds);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/persistence/SpringDataProductRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/catalog/infrastructure/persistence/SpringDataProductRepository.java
@@ -3,6 +3,7 @@ package br.com.f2e.ovenplatform.catalog.infrastructure.persistence;
 import br.com.f2e.ovenplatform.catalog.domain.Product;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface SpringDataProductRepository extends JpaRepository<Product, UUID
   Optional<Product> findByIdAndTenantId(UUID id, UUID tenantId);
 
   List<Product> findByTenantIdAndActiveTrue(UUID tenantId);
+
+  List<Product> findByTenantIdAndIdInAndActiveTrue(UUID tenantId, Set<UUID> productIds);
 }

--- a/src/test/java/br/com/f2e/ovenplatform/catalog/application/CatalogProductLookupIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/catalog/application/CatalogProductLookupIntegrationTest.java
@@ -1,0 +1,155 @@
+package br.com.f2e.ovenplatform.catalog.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import br.com.f2e.ovenplatform.catalog.application.api.CatalogProductLookup;
+import br.com.f2e.ovenplatform.catalog.application.api.SellableProduct;
+import br.com.f2e.ovenplatform.catalog.domain.Product;
+import br.com.f2e.ovenplatform.catalog.infrastructure.persistence.JpaProductRepositoryAdapter;
+import br.com.f2e.ovenplatform.tenant.domain.Plan;
+import br.com.f2e.ovenplatform.tenant.domain.Tenant;
+import br.com.f2e.ovenplatform.tenant.infrastructure.persistence.SpringDataTenantRepository;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({CatalogProductLookupService.class, JpaProductRepositoryAdapter.class})
+@EnableJpaAuditing
+class CatalogProductLookupIntegrationTest {
+
+  @Autowired private CatalogProductLookup catalogProductLookup;
+  @Autowired private ProductRepository productRepository;
+  @Autowired private SpringDataTenantRepository tenantRepository;
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  void shouldFindSellableProductsWithCurrentPricesByTenantIdAndIds() {
+
+    var tenant = createTenant();
+    var products = createProducts(tenant, 4, true);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var resultMap = products.stream().collect(Collectors.toMap(Product::getId, Product::getPrice));
+    var sellableProducts =
+        catalogProductLookup.findSellableProducts(tenant.getId(), resultMap.keySet());
+
+    var actualPricesByProductId =
+        sellableProducts.stream()
+            .collect(Collectors.toMap(SellableProduct::productId, SellableProduct::price));
+
+    assertThat(actualPricesByProductId.keySet())
+        .containsExactlyInAnyOrderElementsOf(resultMap.keySet());
+
+    resultMap.forEach(
+        (productId, expectedPrice) ->
+            assertThat(actualPricesByProductId.get(productId)).isEqualByComparingTo(expectedPrice));
+  }
+
+  @Test
+  void shouldNotReturnInactiveProducts() {
+    var tenant = createTenant();
+    var activeProducts = createProducts(tenant, 2, true);
+    var inactiveProducts = createProducts(tenant, 4, false);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var requestedProductIds =
+        Stream.concat(activeProducts.stream(), inactiveProducts.stream())
+            .map(Product::getId)
+            .collect(Collectors.toSet());
+
+    var activeProductIds = activeProducts.stream().map(Product::getId).toList();
+
+    var sellableProducts =
+        catalogProductLookup.findSellableProducts(tenant.getId(), requestedProductIds);
+
+    assertThat(sellableProducts).hasSize(activeProducts.size());
+
+    assertThat(sellableProducts)
+        .extracting(SellableProduct::productId)
+        .containsExactlyInAnyOrderElementsOf(activeProductIds);
+  }
+
+  @Test
+  void shouldNotReturnProductsFromAnotherTenant() {
+    var tenant = createTenant();
+    var productsFromTenant = createProducts(tenant, 1, true);
+
+    var anotherTenant = createTenant("La bella pizza");
+    var productsFromAnotherTenant = createProducts(anotherTenant, 4, true);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    var requestedProductIds =
+        Stream.concat(productsFromTenant.stream(), productsFromAnotherTenant.stream())
+            .map(Product::getId)
+            .collect(Collectors.toSet());
+
+    var expectedProductIds = productsFromTenant.stream().map(Product::getId).toList();
+    var anotherTenantProductIds = productsFromAnotherTenant.stream().map(Product::getId).toList();
+
+    var sellableProducts =
+        catalogProductLookup.findSellableProducts(tenant.getId(), requestedProductIds);
+
+    assertThat(sellableProducts).hasSize(productsFromTenant.size());
+
+    assertThat(sellableProducts)
+        .extracting(SellableProduct::productId)
+        .containsExactlyInAnyOrderElementsOf(expectedProductIds);
+
+    assertThat(sellableProducts)
+        .extracting(SellableProduct::productId)
+        .doesNotContainAnyElementsOf(anotherTenantProductIds);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenNoProductMatches() {
+
+    var tenant = createTenant();
+    createProducts(tenant, 3, true);
+
+    entityManager.flush();
+    entityManager.clear();
+
+    assertThat(catalogProductLookup.findSellableProducts(tenant.getId(), Set.of(UUID.randomUUID())))
+        .isEmpty();
+  }
+
+  private List<Product> createProducts(Tenant tenant, int quantity, boolean active) {
+    List<Product> products = new ArrayList<>(quantity);
+
+    for (int i = 1; i <= quantity; i++) {
+      Product product = new Product(tenant.getId(), "Product %d".formatted(i), new BigDecimal(i));
+      if (!active) {
+        product.deactivate();
+      }
+      products.add(productRepository.save(product));
+    }
+    return products;
+  }
+
+  private Tenant createTenant(String name) {
+    return tenantRepository.save(new Tenant(name, Plan.MVP));
+  }
+
+  private Tenant createTenant() {
+    return createTenant("Pizarria da mama");
+  }
+}


### PR DESCRIPTION
## 🎯 Summary

Adds a public Catalog lookup to resolve sellable products by tenant and product IDs.

This enables the Orders module to retrieve trusted server-side product prices without depending on Catalog entities, repositories, or persistence details.

## 💼 Business Value

- Ensures product prices used in orders are validated on the backend
- Keeps Catalog as the single source of truth for product pricing
- Prevents client-side price manipulation
- Establishes a clean module boundary for cross-module communication

## 🏗️ What was implemented

### Catalog public API

- `CatalogProductLookup`
- `SellableProduct`

```text
findSellableProducts(UUID tenantId, Set<UUID> productIds)
```

Returns only:

- products that belong to the tenant
- products that are active/sellable
- product ID + current price

### Application layer

- `CatalogProductLookupService` implements the public API
- Uses `ProductRepository` as the internal Catalog persistence port
- Maps `Product` to `SellableProduct`

### Persistence

- Added batch lookup support through the internal `ProductRepository` port
- Implemented the lookup in `JpaProductRepositoryAdapter`
- Backed by a Spring Data repository query

## 🧪 Tests

Added DB-backed integration tests covering:

- returns sellable products with correct current prices
- filters out inactive products
- filters out products from another tenant
- returns empty when no products match

Tests assert product IDs without relying on ordering and validate the correct price per product ID.

## 🧱 Architecture Notes

- Does not expose the `Product` entity outside Catalog
- Does not expose `ProductRepository` outside Catalog
- Keeps Catalog as the owner of product data and pricing rules
- Provides a clean public application API for future Orders integration
- Does not introduce events or product projections in this PR

Expected future flow:

```text
Orders application
  -> OrderableProductProvider

Orders infrastructure/catalog adapter
  -> CatalogProductLookup

Catalog application
  -> ProductRepository
```

## 🚫 Out of Scope

- Order creation (`POST /orders`)
- Orders module adapter/port
- Catalog-to-Orders product projection
- Event-based product pricing
- External messaging

Closes #21