### PR TITLE
feat(orders): add order creation endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 .vscode/
 
 .env
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <java.version>25</java.version>
         <spring-modulith.version>2.0.3</spring-modulith.version>
         <spotless.version>3.4.0</spotless.version>
+        <spotbug.version>4.9.8</spotbug.version>
         <jacoco.version>0.8.13</jacoco.version>
         <jjwt.version>0.13.0</jjwt.version>
 
@@ -141,6 +142,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>${spotbug.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -251,8 +258,9 @@
                     <dependency>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs</artifactId>
-                        <version>4.9.8</version>
+                        <version>${spotbug.version}</version>
                     </dependency>
+
                 </dependencies>
                 <executions>
                     <execution>

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/CreateOrderCommand.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/CreateOrderCommand.java
@@ -1,0 +1,10 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import java.util.List;
+
+public record CreateOrderCommand(List<CreateOrderItemCommand> items) {
+
+  public CreateOrderCommand {
+    items = List.copyOf(items);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/CreateOrderItemCommand.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/CreateOrderItemCommand.java
@@ -1,0 +1,5 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import java.util.UUID;
+
+public record CreateOrderItemCommand(UUID productId, int quantity) {}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
@@ -4,23 +4,51 @@ import br.com.f2e.ovenplatform.orders.domain.Order;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
 public class OrderService {
 
   private final OrderRepository orderRepository;
+  private final OrderableProductProvider orderableProductProvider;
 
-  public OrderService(OrderRepository orderRepository) {
+  public OrderService(
+      OrderRepository orderRepository, OrderableProductProvider orderableProductProvider) {
     this.orderRepository = orderRepository;
+    this.orderableProductProvider = orderableProductProvider;
   }
 
   public Order save(Order order) {
     return orderRepository.save(order);
   }
 
-  public Order createOrder(UUID tenantId) {
-    return orderRepository.save(new Order(tenantId));
+  public Order createOrder(UUID tenantId, CreateOrderCommand orderCommand) {
+    var productIds =
+        orderCommand.items().stream()
+            .map(CreateOrderItemCommand::productId)
+            .collect(Collectors.toSet());
+
+    var orderableProducts =
+        orderableProductProvider.findOrderableProducts(tenantId, productIds).stream()
+            .collect(Collectors.toMap(OrderableProduct::productId, OrderableProduct::unitPrice));
+
+    var order = new Order(tenantId);
+
+    orderCommand
+        .items()
+        .forEach(
+            item -> {
+              var unitPrice = orderableProducts.get(item.productId());
+
+              if (unitPrice == null) {
+                throw new ProductNotAvailableForOrderingException(item.productId());
+              }
+
+              order.addItem(item.productId(), item.quantity(), unitPrice);
+            });
+
+    return orderRepository.save(order);
   }
 
   public Optional<Order> findOrder(UUID tenantId, UUID orderId) {

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderableProduct.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderableProduct.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record OrderableProduct(UUID productId, BigDecimal unitPrice) {}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderableProductProvider.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderableProductProvider.java
@@ -1,0 +1,10 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public interface OrderableProductProvider {
+
+  List<OrderableProduct> findOrderableProducts(UUID tenantId, Set<UUID> productIds);
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/ProductNotAvailableForOrderingException.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/ProductNotAvailableForOrderingException.java
@@ -1,0 +1,10 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import java.util.UUID;
+
+public class ProductNotAvailableForOrderingException extends RuntimeException {
+
+  public ProductNotAvailableForOrderingException(UUID productId) {
+    super("Product is not available for ordering: " + productId);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/catalog/CatalogOrderableProductProvider.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/catalog/CatalogOrderableProductProvider.java
@@ -1,0 +1,28 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.catalog;
+
+import br.com.f2e.ovenplatform.catalog.application.api.CatalogProductLookup;
+import br.com.f2e.ovenplatform.orders.application.OrderableProduct;
+import br.com.f2e.ovenplatform.orders.application.OrderableProductProvider;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CatalogOrderableProductProvider implements OrderableProductProvider {
+
+  private final CatalogProductLookup catalogProductLookup;
+
+  public CatalogOrderableProductProvider(CatalogProductLookup catalogProductLookup) {
+    this.catalogProductLookup = catalogProductLookup;
+  }
+
+  @Override
+  public List<OrderableProduct> findOrderableProducts(UUID tenantId, Set<UUID> productIds) {
+    return catalogProductLookup.findSellableProducts(tenantId, productIds).stream()
+        .map(
+            sellableProduct ->
+                new OrderableProduct(sellableProduct.productId(), sellableProduct.price()))
+        .toList();
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/CreateOrderRequest.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/CreateOrderRequest.java
@@ -1,0 +1,23 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.web;
+
+import br.com.f2e.ovenplatform.orders.application.CreateOrderCommand;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@SuppressFBWarnings(
+    value = "EI_EXPOSE_REP",
+    justification =
+        "Request DTO intentionally stores raw client input so Bean Validation can produce proper 400 responses for invalid/null collections.")
+public record CreateOrderRequest(
+    @NotNull(message = "must not be null")
+        @Size(min = 1, message = "items must have at least 1 item")
+        @Valid
+        List<OrderItemRequest> items) {
+
+  public CreateOrderCommand toCommand() {
+    return new CreateOrderCommand(items.stream().map(OrderItemRequest::toCommand).toList());
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
@@ -1,0 +1,41 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.web;
+
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
+
+import br.com.f2e.ovenplatform.orders.application.OrderService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@RestController
+@RequestMapping("/orders")
+public class OrderController {
+
+  private final OrderService orderService;
+
+  public OrderController(OrderService orderService) {
+    this.orderService = orderService;
+  }
+
+  @PostMapping(version = "1.0")
+  ResponseEntity<OrderResponse> create(
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId,
+      @Valid @RequestBody CreateOrderRequest orderRequest,
+      HttpServletRequest request) {
+
+    var orderResponse =
+        OrderResponse.from(orderService.createOrder(tenantId, orderRequest.toCommand()));
+    var uri =
+        UriComponentsBuilder.fromPath(request.getRequestURI() + "/{id}")
+            .buildAndExpand(orderResponse.id())
+            .toUri();
+    return ResponseEntity.created(uri).body(orderResponse);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderItemRequest.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderItemRequest.java
@@ -1,0 +1,12 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.web;
+
+import br.com.f2e.ovenplatform.orders.application.CreateOrderItemCommand;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.UUID;
+
+public record OrderItemRequest(@NotNull UUID productId, @Positive int quantity) {
+  public CreateOrderItemCommand toCommand() {
+    return new CreateOrderItemCommand(productId, quantity);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderItemResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderItemResponse.java
@@ -1,0 +1,21 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.web;
+
+import br.com.f2e.ovenplatform.orders.domain.OrderItem;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderItemResponse(
+    UUID productId, int quantity, BigDecimal unitPrice, BigDecimal subtotal) {
+  public static List<OrderItemResponse> from(List<OrderItem> items) {
+    return items.stream()
+        .map(
+            item ->
+                new OrderItemResponse(
+                    item.getProductId(),
+                    item.getQuantity(),
+                    item.getUnitPrice(),
+                    item.getSubtotal()))
+        .toList();
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderResponse.java
@@ -1,0 +1,28 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.web;
+
+import br.com.f2e.ovenplatform.orders.domain.Order;
+import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderResponse(
+    UUID id,
+    UUID tenantId,
+    OrderStatus status,
+    BigDecimal totalAmount,
+    List<OrderItemResponse> items) {
+
+  public OrderResponse {
+    items = List.copyOf(items);
+  }
+
+  public static OrderResponse from(Order order) {
+    return new OrderResponse(
+        order.getId(),
+        order.getTenantId(),
+        order.getStatus(),
+        order.getTotalAmount(),
+        OrderItemResponse.from(order.getItems()));
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
@@ -1,24 +1,27 @@
 package br.com.f2e.ovenplatform.orders.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import br.com.f2e.ovenplatform.catalog.domain.Product;
-import br.com.f2e.ovenplatform.catalog.infrastructure.persistence.SpringDataProductRepository;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
 import br.com.f2e.ovenplatform.orders.infrastructure.persistence.JpaOrderRepositoryAdapter;
-import br.com.f2e.ovenplatform.tenant.domain.Plan;
-import br.com.f2e.ovenplatform.tenant.domain.Tenant;
-import br.com.f2e.ovenplatform.tenant.infrastructure.persistence.SpringDataTenantRepository;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -26,69 +29,78 @@ import org.springframework.test.context.ActiveProfiles;
 @EnableJpaAuditing
 class OrderServiceIntegrationTest {
 
-  private static final BigDecimal UNIT_PRICE = new BigDecimal("35.40");
+  private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
+
+  private static final UUID ANOTHER_TENANT_ID =
+      UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecd");
+
+  private record OrderItemFixture(
+      CreateOrderItemCommand command, OrderableProduct orderableProduct) {}
 
   @Autowired private OrderService orderService;
-  @Autowired private SpringDataTenantRepository tenantRepository;
-  @Autowired private SpringDataProductRepository productRepository;
   @Autowired private EntityManager entityManager;
 
+  @SuppressWarnings("unused")
+  @MockitoBean
+  private OrderableProductProvider orderableProductProvider;
+
   @Test
-  void shouldCreateOrder() {
+  void shouldCreateOrderWithItemsUsingOrderableProductPrices() {
+    var fixtures = createOrderItemFixtures();
+    var command = createOrderCommand(fixtures);
+    var orderableProducts = createOrderableProducts(fixtures);
+    var productIds = extractProductIds(command);
 
-    var tenant = createTenant();
-    var order = orderService.createOrder(tenant.getId());
+    when(orderableProductProvider.findOrderableProducts(TENANT_ID, productIds))
+        .thenReturn(orderableProducts);
 
-    assertThat(order.getTenantId()).isEqualTo(tenant.getId());
+    var order = orderService.createOrder(TENANT_ID, command);
+
+    assertThat(order.getTenantId()).isEqualTo(TENANT_ID);
     assertThat(order.getId()).isNotNull();
     assertThat(order.getStatus()).isEqualTo(OrderStatus.CREATED);
-    assertThat(order.getItems()).isEmpty();
+    assertThat(order.getItems()).hasSize(fixtures.size());
+
+    assertOrderItemsMatchFixtures(order, fixtures);
+
+    verify(orderableProductProvider).findOrderableProducts(TENANT_ID, productIds);
   }
 
   @Test
   void shouldSaveAndFindOrderWithItems() {
-    var tenant = createTenant();
-    var product = createProduct(tenant);
-
-    var order = new Order(tenant.getId());
-    var quantity = 2;
-
-    order.addItem(product.getId(), quantity, UNIT_PRICE);
+    var order = createOrderWithItems(TENANT_ID, 1);
 
     var savedOrder = orderService.save(order);
 
     entityManager.flush();
     entityManager.clear();
 
-    var foundOrder = orderService.findOrderWithItems(tenant.getId(), savedOrder.getId());
+    var foundOrder = orderService.findOrderWithItems(TENANT_ID, savedOrder.getId());
 
     assertThat(foundOrder).isPresent();
 
     var persistedOrder = foundOrder.get();
 
-    var expectedPrice = "70.80";
-
     assertThat(persistedOrder.getStatus()).isEqualTo(OrderStatus.CREATED);
-    assertThat(persistedOrder.getTotalAmount()).isEqualByComparingTo(expectedPrice);
+    assertThat(persistedOrder.getTotalAmount()).isEqualByComparingTo("1.00");
     assertThat(persistedOrder.getItems()).hasSize(1);
 
     var item = persistedOrder.getItems().getFirst();
 
-    assertThat(item.getProductId()).isEqualTo(product.getId());
-    assertThat(item.getQuantity()).isEqualTo(quantity);
-    assertThat(item.getUnitPrice()).isEqualByComparingTo(UNIT_PRICE);
-    assertThat(item.getSubtotal()).isEqualByComparingTo(expectedPrice);
+    assertThat(item.getProductId()).isEqualTo(order.getItems().getFirst().getProductId());
+    assertThat(item.getQuantity()).isEqualTo(1);
+    assertThat(item.getUnitPrice()).isEqualByComparingTo("1.00");
+    assertThat(item.getSubtotal()).isEqualByComparingTo("1.00");
   }
 
   @Test
   void shouldFindOrderByIdAndTenantId() {
-    var tenant = createTenant();
-    var savedOrder = orderService.createOrder(tenant.getId());
+    var savedOrder = orderService.save(createOrderWithItems(TENANT_ID, 1));
 
     entityManager.flush();
     entityManager.clear();
 
-    var foundOrder = orderService.findOrder(tenant.getId(), savedOrder.getId());
+    var foundOrder = orderService.findOrder(TENANT_ID, savedOrder.getId());
 
     assertThat(foundOrder)
         .isPresent()
@@ -96,70 +108,124 @@ class OrderServiceIntegrationTest {
         .satisfies(
             order -> {
               assertThat(order.getId()).isEqualTo(savedOrder.getId());
-              assertThat(order.getTenantId()).isEqualTo(tenant.getId());
+              assertThat(order.getTenantId()).isEqualTo(TENANT_ID);
               assertThat(order.getStatus()).isEqualTo(OrderStatus.CREATED);
-              assertThat(order.getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+              assertThat(order.getTotalAmount()).isEqualByComparingTo("1.00");
             });
   }
 
   @Test
   void shouldReturnEmptyWhenOrderDoesNotExist() {
-
-    var tenant = createTenant();
     var unknownOrderId = UUID.randomUUID();
 
-    var order = orderService.findOrder(tenant.getId(), unknownOrderId);
+    var order = orderService.findOrder(TENANT_ID, unknownOrderId);
 
     assertThat(order).isEmpty();
   }
 
   @Test
   void shouldReturnEmptyWhenOrderBelongsToAnotherTenant() {
-    var tenant = createTenant();
-    var anotherTenant = createTenant("Soprano Pizzeria");
-    var order = orderService.createOrder(tenant.getId());
+    var order = orderService.save(createOrderWithItems(TENANT_ID, 1));
 
     entityManager.flush();
     entityManager.clear();
 
-    assertThat(orderService.findOrder(anotherTenant.getId(), order.getId())).isEmpty();
+    assertThat(orderService.findOrder(ANOTHER_TENANT_ID, order.getId())).isEmpty();
   }
 
   @Test
   void shouldListOrdersByTenant() {
-
-    UUID tenantId = createTenant().getId();
-    orderService.createOrder(tenantId);
+    orderService.save(createOrderWithItems(TENANT_ID, 1));
+    orderService.save(createOrderWithItems(TENANT_ID, 2));
+    orderService.save(createOrderWithItems(ANOTHER_TENANT_ID, 1));
 
     entityManager.flush();
     entityManager.clear();
 
-    var orders = orderService.listOrders(tenantId);
+    var orders = orderService.listOrders(TENANT_ID);
 
-    assertThat(orders).hasSize(1).extracting(Order::getTenantId).containsOnly(tenantId);
+    assertThat(orders).hasSize(2).extracting(Order::getTenantId).containsOnly(TENANT_ID);
   }
 
   @Test
   void shouldNotListOrdersFromAnotherTenant() {
-
-    UUID tenantId = createTenant().getId();
-    orderService.createOrder(tenantId);
+    orderService.save(createOrderWithItems(TENANT_ID, 1));
 
     entityManager.flush();
     entityManager.clear();
 
-    assertThat(orderService.listOrders(createTenant("La mama").getId())).isEmpty();
+    assertThat(orderService.listOrders(ANOTHER_TENANT_ID)).isEmpty();
   }
 
-  private Tenant createTenant() {
-    return createTenant("Don Corleone Pizzeria");
+  @Test
+  void shouldThrowExceptionWhenCatalogReturnNullProduct() {
+    var productId = UUID.randomUUID();
+    CreateOrderCommand orderCommand =
+        new CreateOrderCommand(List.of(new CreateOrderItemCommand(productId, 1)));
+    assertThatThrownBy(() -> orderService.createOrder(TENANT_ID, orderCommand))
+        .isInstanceOf(ProductNotAvailableForOrderingException.class)
+        .hasMessage("Product is not available for ordering: %s".formatted(productId));
   }
 
-  private Tenant createTenant(String name) {
-    return tenantRepository.save(new Tenant(name, Plan.MVP));
+  private Order createOrderWithItems(UUID tenantId, int itemQuantity) {
+    var order = new Order(tenantId);
+    order.addItem(UUID.randomUUID(), itemQuantity, BigDecimal.ONE);
+    return order;
   }
 
-  private Product createProduct(Tenant tenant) {
-    return productRepository.save(new Product(tenant.getId(), "Pizza portuguesa", UNIT_PRICE));
+  private List<OrderItemFixture> createOrderItemFixtures() {
+    var itemCount = 3;
+    var fixtures = new ArrayList<OrderItemFixture>(itemCount);
+
+    for (int i = 1; i <= itemCount; i++) {
+      var productId = UUID.randomUUID();
+      var unitPrice = BigDecimal.valueOf(i);
+
+      fixtures.add(
+          new OrderItemFixture(
+              new CreateOrderItemCommand(productId, i),
+              new OrderableProduct(productId, unitPrice)));
+    }
+
+    return fixtures;
+  }
+
+  private CreateOrderCommand createOrderCommand(List<OrderItemFixture> fixtures) {
+    return new CreateOrderCommand(fixtures.stream().map(OrderItemFixture::command).toList());
+  }
+
+  private List<OrderableProduct> createOrderableProducts(List<OrderItemFixture> fixtures) {
+    return fixtures.stream().map(OrderItemFixture::orderableProduct).toList();
+  }
+
+  private Set<UUID> extractProductIds(CreateOrderCommand command) {
+    return command.items().stream()
+        .map(CreateOrderItemCommand::productId)
+        .collect(Collectors.toSet());
+  }
+
+  private void assertOrderItemsMatchFixtures(Order order, List<OrderItemFixture> fixtures) {
+    var expectedItemsByProductId =
+        fixtures.stream()
+            .collect(
+                Collectors.toMap(fixture -> fixture.command().productId(), fixture -> fixture));
+
+    order
+        .getItems()
+        .forEach(
+            item -> {
+              var fixture = expectedItemsByProductId.get(item.getProductId());
+
+              assertThat(fixture).isNotNull();
+              assertThat(item.getQuantity()).isEqualTo(fixture.command().quantity());
+              assertThat(item.getUnitPrice())
+                  .isEqualByComparingTo(fixture.orderableProduct().unitPrice());
+              assertThat(item.getSubtotal())
+                  .isEqualByComparingTo(
+                      fixture
+                          .orderableProduct()
+                          .unitPrice()
+                          .multiply(BigDecimal.valueOf(fixture.command().quantity())));
+            });
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
@@ -1,0 +1,203 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.web;
+
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import br.com.f2e.ovenplatform.identity.infrastructure.security.JwtService;
+import br.com.f2e.ovenplatform.orders.application.CreateOrderCommand;
+import br.com.f2e.ovenplatform.orders.application.OrderService;
+import br.com.f2e.ovenplatform.orders.domain.Order;
+import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
+import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
+import br.com.f2e.ovenplatform.shared.util.JsonUtils;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+@WebMvcTest(controllers = OrderController.class)
+@Import(TraceContext.class)
+class OrderControllerTest {
+
+  private static final String BASE_URL = "/orders";
+  private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
+  private static final UUID PRODUCT_ID = UUID.fromString("b6210129-f1d5-4942-8d0a-b144e518aecc");
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private OrderService orderService;
+  @MockitoBean private JwtService jwtService;
+
+  @Test
+  void shouldCreateOrderWithItems() throws Exception {
+    var orderRequest = new CreateOrderRequest(List.of(new OrderItemRequest(PRODUCT_ID, 3)));
+
+    var order = createOrder(TENANT_ID, PRODUCT_ID, 3, new BigDecimal("35.40"));
+
+    when(orderService.createOrder(eq(TENANT_ID), any(CreateOrderCommand.class))).thenReturn(order);
+
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtils.toJson(orderRequest))
+                .header(TENANT_ID_HEADER, TENANT_ID))
+        .andExpect(status().isCreated())
+        .andExpect(header().string("Location", "/orders/" + order.getId()))
+        .andExpect(jsonPath("$.id").value(order.getId().toString()))
+        .andExpect(jsonPath("$.tenantId").value(TENANT_ID.toString()))
+        .andExpect(jsonPath("$.status").value("CREATED"))
+        .andExpect(jsonPath("$.totalAmount").value(106.20))
+        .andExpect(jsonPath("$.items").isArray())
+        .andExpect(jsonPath("$.items.length()").value(1))
+        .andExpect(jsonPath("$.items[0].productId").value(PRODUCT_ID.toString()))
+        .andExpect(jsonPath("$.items[0].quantity").value(3))
+        .andExpect(jsonPath("$.items[0].unitPrice").value(35.40))
+        .andExpect(jsonPath("$.items[0].subtotal").value(106.20));
+
+    var commandCaptor = ArgumentCaptor.forClass(CreateOrderCommand.class);
+
+    verify(orderService).createOrder(eq(TENANT_ID), commandCaptor.capture());
+
+    var command = commandCaptor.getValue();
+
+    assertThat(command.items()).hasSize(1);
+    assertThat(command.items().getFirst().productId()).isEqualTo(PRODUCT_ID);
+    assertThat(command.items().getFirst().quantity()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenTenantHeaderIsMissing() throws Exception {
+    var orderRequest = new CreateOrderRequest(List.of(new OrderItemRequest(PRODUCT_ID, 3)));
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtils.toJson(orderRequest)))
+        .andExpect(status().isBadRequest())
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                BASE_URL,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.MISSING_REQUEST_HEADER,
+                "Required request header 'X-Tenant-Id' for method parameter type UUID is not present",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(orderService);
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenTenantHeaderIsInvalid() throws Exception {
+    var orderRequest = new CreateOrderRequest(List.of(new OrderItemRequest(PRODUCT_ID, 3)));
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtils.toJson(orderRequest))
+                .header(TENANT_ID_HEADER, "invalid-request-id"))
+        .andExpect(status().isBadRequest())
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                BASE_URL,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.INVALID_ARGUMENT,
+                "Invalid UUID string: invalid-request-id",
+                null,
+                HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(orderService);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("invalidCreateOrderRequests")
+  void shouldReturnBadRequestWhenRequestBodyIsInvalid(
+      String field, String message, CreateOrderRequest request) throws Exception {
+    mockMvc
+        .perform(
+            post(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtils.toJson(request))
+                .header(TENANT_ID_HEADER, TENANT_ID)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpectAll(
+            validationErrors(
+                HttpStatus.BAD_REQUEST,
+                BASE_URL,
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                ApiErrorCodes.VALIDATION_ERROR,
+                message,
+                field,
+                HttpStatus.BAD_REQUEST.value()));
+
+    verifyNoInteractions(orderService);
+  }
+
+  private Order createOrder(UUID tenantId, UUID productId, int quantity, BigDecimal unitPrice) {
+    var order = new Order(tenantId);
+    order.addItem(productId, quantity, unitPrice);
+    return order;
+  }
+
+  private static Stream<Arguments> invalidCreateOrderRequests() {
+    return Stream.of(
+        Arguments.of("items", "must not be null", new CreateOrderRequest(null)),
+        Arguments.of("items", "items must have at least 1 item", new CreateOrderRequest(List.of())),
+        Arguments.of(
+            "items[0].productId",
+            "must not be null",
+            new CreateOrderRequest(List.of(new OrderItemRequest(null, 1)))),
+        Arguments.of(
+            "items[0].quantity",
+            "must be greater than 0",
+            new CreateOrderRequest(List.of(new OrderItemRequest(UUID.randomUUID(), 0)))),
+        Arguments.of(
+            "items[0].quantity",
+            "must be greater than 0",
+            new CreateOrderRequest(List.of(new OrderItemRequest(UUID.randomUUID(), -1)))));
+  }
+
+  private ResultMatcher[] validationErrors(
+      HttpStatus httpStatus,
+      String path,
+      String error,
+      String code,
+      String message,
+      String field,
+      int statusCode) {
+    return new ResultMatcher[] {
+      status().is(httpStatus.value()),
+      jsonPath("$.path").value(path),
+      jsonPath("$.error").value(error),
+      jsonPath("$.traceId").isNotEmpty(),
+      jsonPath("$.errors[0].code").value(code),
+      jsonPath("$.errors[0].message").value(message),
+      jsonPath("$.errors[0].field").value(field),
+      jsonPath("$.status").value(statusCode)
+    };
+  }
+}


### PR DESCRIPTION
## 🎯 Summary

Adds the first Orders HTTP endpoint to create customer orders with items.

The endpoint accepts selected products and quantities, resolves trusted server-side product prices through the Orders application port, persists the order with item price snapshots, and returns the created order response.

## 💼 Business Value

- Allows tenant users to create customer orders through the API
- Prevents client-side price manipulation by resolving prices server-side
- Keeps Orders decoupled from Catalog internals through an application port
- Establishes the first external entry point for the Orders module

## 🏗️ What changed

### Orders application

- Added `CreateOrderCommand`
- Added `CreateOrderItemCommand`
- Added `OrderableProduct`
- Added `OrderableProductProvider`
- Added `ProductNotAvailableForOrderingException`
- Updated `OrderService` to create orders with items using resolved orderable product prices
- Removed the empty-order creation flow from `OrderService`
- Added explicit handling for products that are not available for ordering

### Catalog integration adapter

- Added `CatalogOrderableProductProvider`
- Maps Catalog `SellableProduct` to Orders `OrderableProduct`
- Keeps Orders depending on its own port instead of Catalog implementation details

### Orders web layer

- Added `OrderController`
- Added `POST /orders` with API version `1.0`
- Added request DTOs:
  - `CreateOrderRequest`
  - `OrderItemRequest`
- Added response DTOs:
  - `OrderResponse`
  - `OrderItemResponse`
- Returns `201 Created`
- Returns `Location: /orders/{id}`
- Returns created order body with items, unit prices, subtotals, and total amount

### Build/tooling

- Added `spotbugs-annotations` as a provided dependency to support targeted SpotBugs suppressions in source code
- Added `.DS_Store` to `.gitignore` and removed the existing tracked file

## 🧪 Tests

- Updated `OrderServiceIntegrationTest` to create orders with items and mocked orderable product lookup
- Added service coverage for products not available for ordering
- Added `OrderControllerTest` covering:
  - successful order creation
  - response body mapping
  - `Location` header
  - request-to-command mapping
  - missing tenant header
  - invalid tenant header
  - invalid request body scenarios
  - no service call on invalid requests

## 🧱 Architecture Notes

- `OrderController` depends only on `OrderService`
- `OrderService` depends on the Orders-owned `OrderableProductProvider` port
- Catalog integration is isolated in `orders.infrastructure.catalog`
- Product price is copied into `OrderItem.unitPrice` as a snapshot
- Controller does not access repositories, Catalog services, or persistence adapters directly
- Product availability is intentionally expressed in Orders language instead of exposing Catalog internals

## 🚫 Out of Scope

- Mapping `ProductNotAvailableForOrderingException` to a public API error response
- Updating order status
- Listing orders through HTTP
- Getting order details through HTTP
- Adding/removing items after creation
- Cart/draft order workflow
- Events/outbox/idempotency
- Shared URI builder refactor

Closes #20