### PR TITLE
refactor(db): remove cross-module foreign keys

### DIFF
--- a/src/main/resources/db/changelog/changes/db.changelog-002create-users.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-002create-users.xml
@@ -41,12 +41,6 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addForeignKeyConstraint
-                baseTableName="users"
-                baseColumnNames="tenant_id"
-                constraintName="fk_users_tenant_id"
-                referencedTableName="tenants"
-                referencedColumnNames="id"/>
 
         <addUniqueConstraint
                 tableName="users"

--- a/src/main/resources/db/changelog/changes/db.changelog-003create-products.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-003create-products.xml
@@ -37,13 +37,6 @@
             </column>
         </createTable>
 
-        <addForeignKeyConstraint
-                baseTableName="products"
-                baseColumnNames="tenant_id"
-                constraintName="fk_products_tenant_id"
-                referencedTableName="tenants"
-                referencedColumnNames="id"/>
-
         <createIndex indexName="idx_products_tenant_id" tableName="products">
             <column name="tenant_id"/>
         </createIndex>

--- a/src/main/resources/db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml
@@ -68,24 +68,10 @@
         </createTable>
 
         <addForeignKeyConstraint
-                baseTableName="orders"
-                baseColumnNames="tenant_id"
-                constraintName="fk_orders_tenant_id"
-                referencedTableName="tenants"
-                referencedColumnNames="id"/>
-
-        <addForeignKeyConstraint
                 baseTableName="order_items"
                 baseColumnNames="order_id"
                 constraintName="fk_order_items_order_id"
                 referencedTableName="orders"
-                referencedColumnNames="id"/>
-
-        <addForeignKeyConstraint
-                baseTableName="order_items"
-                baseColumnNames="product_id"
-                constraintName="fk_order_items_product_id"
-                referencedTableName="products"
                 referencedColumnNames="id"/>
 
         <createIndex indexName="idx_orders_tenant_id" tableName="orders">


### PR DESCRIPTION
## 🎯 Summary

Removes physical database foreign keys between modules from the initial Liquibase schema.

Cross-module references are kept as logical IDs, while validation remains enforced at the application layer through module boundaries and ports.

---

## 💼 Business Value

Improves modularity and long-term evolvability of the platform.

Removing cross-module database constraints reduces physical coupling between bounded contexts, keeps modules easier to evolve independently, and better prepares the modular monolith for a possible future service extraction.

---

## 🏗️ What changed

Removed cross-module foreign keys from the initial changelogs:

- `users.tenant_id -> tenants.id`
- `products.tenant_id -> tenants.id`
- `orders.tenant_id -> tenants.id`
- `order_items.product_id -> products.id`

Kept the intra-module aggregate foreign key:

- `order_items.order_id -> orders.id`

Kept existing columns and indexes:

- `tenant_id` columns remain as logical tenant references
- `product_id` remains as a logical Catalog reference
- tenant/product lookup indexes remain unchanged
- `users(tenant_id, email)` unique constraint remains unchanged

---

## 🧱 Architecture Notes

This PR formalizes the current database boundary rule:

```text
Inside the same module:
- database foreign keys are allowed when they protect aggregate/internal consistency

Across module boundaries:
- references should be stored as logical IDs
- consistency should be validated through application-layer ports/services
- modules should not depend physically on each other's tables
```

Applied examples:

```text
order_items.order_id -> orders.id
✅ kept, same Orders aggregate/module

order_items.product_id -> products.id
❌ removed, Orders should not physically depend on Catalog

users/products/orders.tenant_id -> tenants.id
❌ removed, tenant references remain logical IDs
```

---

## 🧪 Tests / Validation

Recommended validation:

- reset the local development database
- run the full test suite
- verify Liquibase applies the initial schema cleanly
- verify order creation still validates product availability through `OrderableProductProvider`
- verify tenant-scoped queries still use logical `tenant_id` references

---

## 🛠️ Migration Note

Because the project is still under active development and the database can be reset, this PR updates the original Liquibase changelogs instead of adding new drop-constraint migrations.

Once environments with persistent/shared data exist, schema changes should be handled through new forward-only migrations.

---

## 🚫 Out of Scope

- Changing business behavior
- Removing columns or indexes
- Changing tenant model
- Changing order creation validation
- Changing entity UUID generation strategy
- Introducing events/outbox
- Extracting modules into services

Closes #67