### PR TITLE
refactor(persistence): use generated UUID identifiers

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/shared/domain/BaseEntity.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/domain/BaseEntity.java
@@ -3,6 +3,8 @@ package br.com.f2e.ovenplatform.shared.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import java.time.Instant;
@@ -15,7 +17,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
-  @Id private UUID id = UUID.randomUUID();
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
 
   @CreatedDate
   @Column(nullable = false, updatable = false)

--- a/src/test/java/br/com/f2e/ovenplatform/catalog/infrastructure/web/ProductControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/catalog/infrastructure/web/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.f2e.ovenplatform.catalog.infrastructure.web;
 
+import static br.com.f2e.ovenplatform.shared.infrastructure.persistence.test.EntityIdTestUtils.withRandomId;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.ApiErrorResponseMatchers.expectValidationErrors;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.LocationHeaderAssertions.assertLocationPath;
@@ -49,7 +50,7 @@ class ProductControllerTest {
   @Test
   void shouldCreateProduct() throws Exception {
 
-    var product = new Product(TENANT_ID, VALID_PRODUCT, VALID_PRICE);
+    var product = withRandomId(new Product(TENANT_ID, VALID_PRODUCT, VALID_PRICE));
     when(catalogService.createProduct(TENANT_ID, VALID_PRODUCT, VALID_PRICE)).thenReturn(product);
 
     var result =

--- a/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/identity/infrastructure/web/IdentityControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.f2e.ovenplatform.identity.infrastructure.web;
 
+import static br.com.f2e.ovenplatform.shared.infrastructure.persistence.test.EntityIdTestUtils.withRandomId;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.API_VERSION_HEADER;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.ApiErrorResponseMatchers.expectValidationErrors;
@@ -361,7 +362,7 @@ class IdentityControllerTest {
   }
 
   private static User createUser() {
-    return new User(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER);
+    return withRandomId(new User(TENANT_ID, EMAIL, PASSWORD, UserRole.MEMBER));
   }
 
   private static DataIntegrityViolationException directConstraintViolation(String constraintName) {

--- a/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.f2e.ovenplatform.orders.infrastructure.web;
 
+import static br.com.f2e.ovenplatform.shared.infrastructure.persistence.test.EntityIdTestUtils.withRandomId;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.ApiErrorResponseMatchers.expectValidationErrors;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.LocationHeaderAssertions.assertLocationPath;
@@ -54,7 +55,7 @@ class OrderControllerTest {
   void shouldCreateOrderWithItems() throws Exception {
     var orderRequest = new CreateOrderRequest(List.of(new OrderItemRequest(PRODUCT_ID, 3)));
 
-    var order = createOrder(TENANT_ID, PRODUCT_ID, 3, new BigDecimal("35.40"));
+    var order = withRandomId(createOrder(TENANT_ID, PRODUCT_ID, 3, new BigDecimal("35.40")));
 
     when(orderService.createOrder(eq(TENANT_ID), any(CreateOrderCommand.class))).thenReturn(order);
 

--- a/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/persistence/test/EntityIdTestUtils.java
+++ b/src/test/java/br/com/f2e/ovenplatform/shared/infrastructure/persistence/test/EntityIdTestUtils.java
@@ -1,0 +1,19 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.persistence.test;
+
+import br.com.f2e.ovenplatform.shared.domain.BaseEntity;
+import java.util.UUID;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public final class EntityIdTestUtils {
+
+  private EntityIdTestUtils() {}
+
+  public static <T extends BaseEntity> T withId(T entity, UUID id) {
+    ReflectionTestUtils.setField(entity, "id", id);
+    return entity;
+  }
+
+  public static <T extends BaseEntity> T withRandomId(T entity) {
+    return withId(entity, UUID.randomUUID());
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/tenant/infrastructure/web/TenantControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.f2e.ovenplatform.tenant.infrastructure.web;
 
+import static br.com.f2e.ovenplatform.shared.infrastructure.persistence.test.EntityIdTestUtils.withId;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.ApiErrorResponseMatchers.expectValidationErrors;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.LocationHeaderAssertions.assertLocationPath;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -19,6 +20,7 @@ import br.com.f2e.ovenplatform.tenant.domain.Status;
 import br.com.f2e.ovenplatform.tenant.domain.Tenant;
 import br.com.f2e.ovenplatform.tenant.infrastructure.web.dto.CreateTenantRequest;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -35,7 +37,8 @@ import org.springframework.test.web.servlet.MockMvc;
 class TenantControllerTest {
 
   private static final String BASE_URL = "/tenants";
-  public static final String TENANT_NAME = "Pizarria bom de garfo";
+  private static final String TENANT_NAME = "Pizarria bom de garfo";
+  private static final UUID TENANT_ID = UUID.randomUUID();
 
   @Autowired private MockMvc mockMvc;
   @MockitoBean private TenantService tenantService;
@@ -111,6 +114,6 @@ class TenantControllerTest {
   }
 
   private Tenant getTenant() {
-    return new Tenant(TENANT_NAME, Plan.MVP);
+    return withId(new Tenant(TENANT_NAME, Plan.MVP), TENANT_ID);
   }
 }


### PR DESCRIPTION
## 🎯 Summary

Updates the entity identifier strategy so UUIDs are generated by the persistence provider instead of being assigned directly in `BaseEntity` during object construction.

This removes the eager `UUID.randomUUID()` initialization from entities and lets Hibernate handle UUID generation through `@GeneratedValue(strategy = GenerationType.UUID)`.

---

## 💼 Business Value

Improves persistence behavior and keeps the entity model closer to standard JPA/Hibernate practices.

New entities no longer start with a preassigned ID before persistence, which avoids ambiguity around whether an entity is new and helps prevent unnecessary select-before-insert behavior.

---

## 🏗️ What changed

### Persistence model

- Updated `BaseEntity` identifier mapping
- Removed direct Java-side ID initialization with `UUID.randomUUID()`
- Added Hibernate/JPA UUID generation via:

```java
@Id
@GeneratedValue(strategy = GenerationType.UUID)
private UUID id;
```

### Test support

- Added a test helper for assigning IDs to non-persisted entities in tests when needed
- Kept reflection isolated in test support instead of spreading it across controller tests
- Updated tests that mock services and return domain entities without going through persistence

---

## 🧱 Architecture Notes

- Entity IDs are now generated as part of persistence lifecycle instead of object construction
- Controller/WebMvc tests that mock application services should not rely on JPA persistence behavior
- When a mocked service returns a domain entity that needs an ID for response mapping or `Location` headers, the ID is assigned through centralized test support
- Persistence/integration tests should continue relying on Hibernate to generate IDs naturally

---

## 🧪 Tests / Validation

Recommended validation:

- run persistence/integration tests
- run WebMvc/controller tests
- verify created entities receive IDs after persistence
- verify mocked controller-test entities use centralized ID test support when required
- verify `Location` header assertions still point to the expected resource path

---

## 🚫 Out of Scope

- Switching to database-generated UUID defaults such as PostgreSQL `gen_random_uuid()`
- Adding PostgreSQL extensions or Liquibase default expressions
- Changing API contracts
- Changing business behavior
- Changing auditing timestamp behavior
- Changing entity relationships
- Changing cross-module FK policy
- Introducing Testcontainers

Closes #62