### PR TITLE
feat(orders): add operational status transitions

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
@@ -1,28 +1,39 @@
 package br.com.f2e.ovenplatform.orders.application;
 
 import br.com.f2e.ovenplatform.orders.domain.Order;
+import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
+import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class OrderService {
 
+  private static final String RESOURCE = "Order";
+
   private final OrderRepository orderRepository;
   private final OrderableProductProvider orderableProductProvider;
+  private final Clock clock;
 
   public OrderService(
-      OrderRepository orderRepository, OrderableProductProvider orderableProductProvider) {
+      OrderRepository orderRepository,
+      OrderableProductProvider orderableProductProvider,
+      Clock clock) {
     this.orderRepository = orderRepository;
     this.orderableProductProvider = orderableProductProvider;
+    this.clock = clock;
   }
 
   public Order save(Order order) {
     return orderRepository.save(order);
   }
 
+  @Transactional
   public Order createOrder(UUID tenantId, CreateOrderCommand orderCommand) {
     var productIds =
         orderCommand.items().stream()
@@ -51,15 +62,42 @@ public class OrderService {
     return orderRepository.save(order);
   }
 
+  @Transactional(readOnly = true)
   public Optional<Order> findOrder(UUID tenantId, UUID orderId) {
     return orderRepository.findByIdAndTenantId(orderId, tenantId);
   }
 
+  @Transactional(readOnly = true)
   public Optional<Order> findOrderWithItems(UUID tenantId, UUID orderId) {
     return orderRepository.findByIdAndTenantIdWithItems(orderId, tenantId);
   }
 
+  @Transactional(readOnly = true)
   public List<Order> listOrders(UUID tenantId) {
     return orderRepository.findByTenantId(tenantId);
+  }
+
+  @Transactional
+  public void markAsReady(UUID tenantId, UUID orderId) {
+    updateOrder(tenantId, orderId, order -> order.markAsReady(clock.instant()));
+  }
+
+  @Transactional
+  public void markAsDelivered(UUID tenantId, UUID orderId) {
+    updateOrder(tenantId, orderId, order -> order.markAsDelivered(clock.instant()));
+  }
+
+  @Transactional
+  public void cancel(UUID tenantId, UUID orderId) {
+    updateOrder(tenantId, orderId, order -> order.cancel(clock.instant()));
+  }
+
+  private void updateOrder(UUID tenantId, UUID orderId, Consumer<Order> operation) {
+    var order =
+        orderRepository
+            .findByIdAndTenantId(orderId, tenantId)
+            .orElseThrow(() -> new ResourceNotFoundException(RESOURCE, orderId));
+
+    operation.accept(order);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/orders/domain/Order.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/domain/Order.java
@@ -2,6 +2,7 @@ package br.com.f2e.ovenplatform.orders.domain;
 
 import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requireNotNull;
 
+import br.com.f2e.ovenplatform.orders.domain.exception.InvalidOrderStatusTransitionException;
 import br.com.f2e.ovenplatform.shared.domain.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -11,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -31,6 +33,15 @@ public class Order extends BaseEntity {
 
   @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
   private final List<OrderItem> items = new ArrayList<>();
+
+  @Column(name = "ready_at")
+  private Instant readyAt;
+
+  @Column(name = "delivered_at")
+  private Instant deliveredAt;
+
+  @Column(name = "cancelled_at")
+  private Instant cancelledAt;
 
   @SuppressWarnings("unused")
   protected Order() {}
@@ -66,5 +77,48 @@ public class Order extends BaseEntity {
 
   public OrderStatus getStatus() {
     return status;
+  }
+
+  public void markAsReady(Instant occurredAt) {
+    if (transitionTo(OrderStatus.READY)) {
+      readyAt = occurredAt;
+    }
+  }
+
+  public void markAsDelivered(Instant occurredAt) {
+    if (transitionTo(OrderStatus.DELIVERED)) {
+      deliveredAt = occurredAt;
+    }
+  }
+
+  public void cancel(Instant occurredAt) {
+    if (transitionTo(OrderStatus.CANCELLED)) {
+      cancelledAt = occurredAt;
+    }
+  }
+
+  public Instant getReadyAt() {
+    return readyAt;
+  }
+
+  public Instant getCancelledAt() {
+    return cancelledAt;
+  }
+
+  public Instant getDeliveredAt() {
+    return deliveredAt;
+  }
+
+  private boolean transitionTo(OrderStatus targetStatus) {
+    if (status == targetStatus) {
+      return false;
+    }
+
+    if (!status.canTransitionTo(targetStatus)) {
+      throw new InvalidOrderStatusTransitionException(status, targetStatus);
+    }
+
+    status = targetStatus;
+    return true;
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/orders/domain/OrderStatus.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/domain/OrderStatus.java
@@ -1,5 +1,33 @@
 package br.com.f2e.ovenplatform.orders.domain;
 
 public enum OrderStatus {
-  CREATED
+  CREATED {
+    @Override
+    boolean canTransitionTo(OrderStatus target) {
+      return target == READY || target == CANCELLED;
+    }
+  },
+
+  READY {
+    @Override
+    boolean canTransitionTo(OrderStatus target) {
+      return target == DELIVERED;
+    }
+  },
+
+  DELIVERED {
+    @Override
+    boolean canTransitionTo(OrderStatus target) {
+      return false;
+    }
+  },
+
+  CANCELLED {
+    @Override
+    boolean canTransitionTo(OrderStatus target) {
+      return false;
+    }
+  };
+
+  abstract boolean canTransitionTo(OrderStatus target);
 }

--- a/src/main/java/br/com/f2e/ovenplatform/orders/domain/exception/InvalidOrderStatusTransitionException.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/domain/exception/InvalidOrderStatusTransitionException.java
@@ -1,0 +1,11 @@
+package br.com.f2e.ovenplatform.orders.domain.exception;
+
+import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
+
+public class InvalidOrderStatusTransitionException extends RuntimeException {
+
+  public InvalidOrderStatusTransitionException(
+      OrderStatus currentStatus, OrderStatus targetStatus) {
+    super("Cannot transition order from " + currentStatus + " to " + targetStatus + ".");
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
@@ -27,7 +27,7 @@ public class OrderController {
   }
 
   @PostMapping(version = API_VERSION_VALUE)
-  ResponseEntity<OrderResponse> create(
+  public ResponseEntity<OrderResponse> create(
       @RequestHeader(TENANT_ID_HEADER) UUID tenantId,
       @Valid @RequestBody CreateOrderRequest orderRequest) {
 
@@ -39,12 +39,33 @@ public class OrderController {
   }
 
   @GetMapping(version = API_VERSION_VALUE, path = "/{id}")
-  ResponseEntity<OrderResponse> findById(
+  public ResponseEntity<OrderResponse> findById(
       @RequestHeader(TENANT_ID_HEADER) UUID tenantId, @PathVariable UUID id) {
     return orderService
         .findOrder(tenantId, id)
         .map(OrderResponse::from)
         .map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  @PostMapping(version = API_VERSION_VALUE, path = "/{id}/mark-ready")
+  public ResponseEntity<Void> markAsReady(
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId, @PathVariable UUID id) {
+    orderService.markAsReady(tenantId, id);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping(version = API_VERSION_VALUE, path = "/{id}/mark-delivered")
+  public ResponseEntity<Void> markAsDelivered(
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId, @PathVariable UUID id) {
+    orderService.markAsDelivered(tenantId, id);
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping(version = API_VERSION_VALUE, path = "/{id}/cancel")
+  public ResponseEntity<Void> cancel(
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId, @PathVariable UUID id) {
+    orderService.cancel(tenantId, id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderResponse.java
@@ -3,6 +3,7 @@ package br.com.f2e.ovenplatform.orders.infrastructure.web;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,6 +12,10 @@ public record OrderResponse(
     UUID tenantId,
     OrderStatus status,
     BigDecimal totalAmount,
+    Instant createdAt,
+    Instant readyAt,
+    Instant deliveredAt,
+    Instant cancelledAt,
     List<OrderItemResponse> items) {
 
   public OrderResponse {
@@ -23,6 +28,10 @@ public record OrderResponse(
         order.getTenantId(),
         order.getStatus(),
         order.getTotalAmount(),
+        order.getCreatedAt(),
+        order.getReadyAt(),
+        order.getDeliveredAt(),
+        order.getCancelledAt(),
         OrderItemResponse.from(order.getItems()));
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/exception/OrderExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/exception/OrderExceptionHandler.java
@@ -1,0 +1,61 @@
+package br.com.f2e.ovenplatform.orders.infrastructure.web.exception;
+
+import br.com.f2e.ovenplatform.orders.application.ProductNotAvailableForOrderingException;
+import br.com.f2e.ovenplatform.orders.domain.exception.InvalidOrderStatusTransitionException;
+import br.com.f2e.ovenplatform.orders.infrastructure.web.OrderController;
+import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
+import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
+import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = OrderController.class)
+public class OrderExceptionHandler {
+
+  @SuppressFBWarnings(
+      value = "EI_EXPOSE_REP2",
+      justification =
+          "TraceContext is a Spring-managed dependency used to read the current request trace id.")
+  private final TraceContext traceContext;
+
+  public OrderExceptionHandler(TraceContext traceContext) {
+    this.traceContext = traceContext;
+  }
+
+  @ExceptionHandler(InvalidOrderStatusTransitionException.class)
+  public ResponseEntity<ApiErrorResponse> invalidOrderStatusTransition(
+      InvalidOrderStatusTransitionException exception, HttpServletRequest request) {
+    return error(
+        HttpStatus.CONFLICT,
+        ApiErrorCodes.INVALID_ORDER_STATUS_TRANSITION,
+        resolveTraceIdForErrorResponse(traceContext),
+        exception.getMessage(),
+        request);
+  }
+
+  @ExceptionHandler(ProductNotAvailableForOrderingException.class)
+  public ResponseEntity<ApiErrorResponse> productNotAvailableForOrdering(
+      ProductNotAvailableForOrderingException exception, HttpServletRequest request) {
+    return error(
+        HttpStatus.NOT_FOUND,
+        ApiErrorCodes.RESOURCE_NOT_FOUND,
+        resolveTraceIdForErrorResponse(traceContext),
+        exception.getMessage(),
+        request);
+  }
+
+  private ResponseEntity<ApiErrorResponse> error(
+      HttpStatus status, String code, String traceId, String message, HttpServletRequest request) {
+    return ResponseEntity.status(status)
+        .body(ApiErrorResponse.of(status, code, traceId, message, request.getRequestURI()));
+  }
+
+  private String resolveTraceIdForErrorResponse(TraceContext traceContext) {
+    return traceContext.findTraceId().orElse(UUID.randomUUID().toString());
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/application/exception/ResourceNotFoundException.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/application/exception/ResourceNotFoundException.java
@@ -1,0 +1,10 @@
+package br.com.f2e.ovenplatform.shared.application.exception;
+
+import java.util.UUID;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+  public ResourceNotFoundException(String resource, UUID id) {
+    super("%s id: %s not found".formatted(resource, id));
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/application/exception/package-info.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/application/exception/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("exception")
+package br.com.f2e.ovenplatform.shared.application.exception;

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/config/AuditingConfig.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/config/AuditingConfig.java
@@ -1,5 +1,5 @@
 /* (C)2026 */
-package br.com.f2e.ovenplatform.shared.config;
+package br.com.f2e.ovenplatform.shared.infrastructure.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/config/TimeConfig.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package br.com.f2e.ovenplatform.shared.infrastructure.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+  @Bean
+  public Clock clock() {
+    return Clock.systemUTC();
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/package-info.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/tracing/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("tracing")
+package br.com.f2e.ovenplatform.shared.infrastructure.tracing;

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorCodes.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/ApiErrorCodes.java
@@ -10,6 +10,7 @@ public final class ApiErrorCodes {
   public static final String DATA_INTEGRITY_VIOLATION = "DATA_INTEGRITY_VIOLATION";
   public static final String MISSING_REQUEST_HEADER = "MISSING_REQUEST_HEADER";
   public static final String INVALID_API_VERSION = "INVALID_API_VERSION";
+  public static final String INVALID_ORDER_STATUS_TRANSITION = "INVALID_ORDER_STATUS_TRANSITION";
 
   private ApiErrorCodes() {}
 }

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;
 
+import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -58,6 +59,17 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(NoSuchElementException.class)
   public ResponseEntity<ApiErrorResponse> notFoundHandler(
       NoSuchElementException exception, HttpServletRequest request) {
+    return error(
+        HttpStatus.NOT_FOUND,
+        ApiErrorCodes.RESOURCE_NOT_FOUND,
+        resolveTraceIdForErrorResponse(traceContext),
+        exception.getMessage(),
+        request);
+  }
+
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<ApiErrorResponse> notFoundResource(
+      ResourceNotFoundException exception, HttpServletRequest request) {
     return error(
         HttpStatus.NOT_FOUND,
         ApiErrorCodes.RESOURCE_NOT_FOUND,

--- a/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/package-info.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/infrastructure/web/exception/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("exception")
+package br.com.f2e.ovenplatform.shared.infrastructure.web.exception;

--- a/src/main/resources/db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml
@@ -31,6 +31,12 @@
             <column name="updated_at" type="timestamp">
                 <constraints nullable="false"/>
             </column>
+
+            <column name="ready_at" type="timestamp"/>
+
+            <column name="delivered_at" type="timestamp"/>
+
+            <column name="cancelled_at" type="timestamp"/>
         </createTable>
 
         <createTable tableName="order_items">

--- a/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
@@ -3,13 +3,17 @@ package br.com.f2e.ovenplatform.orders.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
 import br.com.f2e.ovenplatform.orders.infrastructure.persistence.JpaOrderRepositoryAdapter;
+import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -44,6 +48,8 @@ class OrderServiceIntegrationTest {
   @MockitoBean
   private OrderableProductProvider orderableProductProvider;
 
+  @MockitoBean private Clock clock;
+
   @Test
   void shouldCreateOrderWithItemsUsingOrderableProductPrices() {
     var fixtures = createOrderItemFixtures();
@@ -60,6 +66,8 @@ class OrderServiceIntegrationTest {
     assertThat(order.getId()).isNotNull();
     assertThat(order.getStatus()).isEqualTo(OrderStatus.CREATED);
     assertThat(order.getItems()).hasSize(fixtures.size());
+    assertThat(order.getCreatedAt()).isNotNull();
+    assertThat(order.getUpdatedAt()).isNotNull();
 
     assertOrderItemsMatchFixtures(order, fixtures);
 
@@ -72,8 +80,7 @@ class OrderServiceIntegrationTest {
 
     var savedOrder = orderService.save(order);
 
-    entityManager.flush();
-    entityManager.clear();
+    flushAndClear();
 
     var foundOrder = orderService.findOrderWithItems(TENANT_ID, savedOrder.getId());
 
@@ -97,8 +104,7 @@ class OrderServiceIntegrationTest {
   void shouldFindOrderByIdAndTenantId() {
     var savedOrder = orderService.save(createOrderWithItems(TENANT_ID, 1));
 
-    entityManager.flush();
-    entityManager.clear();
+    flushAndClear();
 
     var foundOrder = orderService.findOrder(TENANT_ID, savedOrder.getId());
 
@@ -127,8 +133,7 @@ class OrderServiceIntegrationTest {
   void shouldReturnEmptyWhenOrderBelongsToAnotherTenant() {
     var order = orderService.save(createOrderWithItems(TENANT_ID, 1));
 
-    entityManager.flush();
-    entityManager.clear();
+    flushAndClear();
 
     assertThat(orderService.findOrder(ANOTHER_TENANT_ID, order.getId())).isEmpty();
   }
@@ -139,8 +144,7 @@ class OrderServiceIntegrationTest {
     orderService.save(createOrderWithItems(TENANT_ID, 2));
     orderService.save(createOrderWithItems(ANOTHER_TENANT_ID, 1));
 
-    entityManager.flush();
-    entityManager.clear();
+    flushAndClear();
 
     var orders = orderService.listOrders(TENANT_ID);
 
@@ -151,8 +155,7 @@ class OrderServiceIntegrationTest {
   void shouldNotListOrdersFromAnotherTenant() {
     orderService.save(createOrderWithItems(TENANT_ID, 1));
 
-    entityManager.flush();
-    entityManager.clear();
+    flushAndClear();
 
     assertThat(orderService.listOrders(ANOTHER_TENANT_ID)).isEmpty();
   }
@@ -165,6 +168,107 @@ class OrderServiceIntegrationTest {
     assertThatThrownBy(() -> orderService.createOrder(TENANT_ID, orderCommand))
         .isInstanceOf(ProductNotAvailableForOrderingException.class)
         .hasMessage("Product is not available for ordering: %s".formatted(productId));
+  }
+
+  @Test
+  void shouldMarkOrderAsReady() {
+    var occurredAt = Instant.parse("2026-05-12T20:18:00Z");
+    when(clock.instant()).thenReturn(occurredAt);
+
+    var savedOrder = orderService.save(createOrderWithItems(TENANT_ID, 1));
+
+    flushAndClear();
+
+    orderService.markAsReady(TENANT_ID, savedOrder.getId());
+
+    flushAndClear();
+
+    var foundOrder = orderService.findOrder(TENANT_ID, savedOrder.getId());
+
+    assertThat(foundOrder)
+        .isPresent()
+        .get()
+        .satisfies(
+            order -> {
+              assertThat(order.getStatus()).isEqualTo(OrderStatus.READY);
+              assertThat(order.getReadyAt()).isEqualTo(occurredAt);
+              assertThat(order.getDeliveredAt()).isNull();
+              assertThat(order.getCancelledAt()).isNull();
+            });
+  }
+
+  @Test
+  void shouldThrowResourceNotFoundWhenMarkingUnknownOrderAsReady() {
+    var orderId = UUID.randomUUID();
+
+    assertThatThrownBy(() -> orderService.markAsReady(TENANT_ID, orderId))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessage("Order id: %s not found".formatted(orderId));
+
+    verifyNoInteractions(clock);
+  }
+
+  @Test
+  void shouldMarkOrderAsDelivered() {
+
+    var readyAt = Instant.parse("2026-05-12T20:18:00Z");
+    var deliveredAt = Instant.parse("2026-05-12T20:30:00Z");
+
+    when(clock.instant()).thenReturn(readyAt, deliveredAt);
+
+    var savedOrder = createReadyOrder();
+
+    flushAndClear();
+
+    orderService.markAsDelivered(TENANT_ID, savedOrder.getId());
+
+    flushAndClear();
+
+    var foundOrder = orderService.findOrder(TENANT_ID, savedOrder.getId());
+
+    assertThat(foundOrder)
+        .isPresent()
+        .get()
+        .satisfies(
+            order -> {
+              assertThat(order.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+              assertThat(order.getReadyAt()).isEqualTo(readyAt);
+              assertThat(order.getDeliveredAt()).isEqualTo(deliveredAt);
+              assertThat(order.getCancelledAt()).isNull();
+            });
+  }
+
+  @Test
+  void shouldMarkOrderAsCancelled() {
+
+    var occurredAt = Instant.parse("2026-05-12T20:18:00Z");
+    when(clock.instant()).thenReturn(occurredAt);
+
+    var savedOrder = orderService.save(createOrderWithItems(TENANT_ID, 1));
+
+    flushAndClear();
+
+    orderService.cancel(TENANT_ID, savedOrder.getId());
+
+    flushAndClear();
+
+    var foundOrder = orderService.findOrder(TENANT_ID, savedOrder.getId());
+
+    assertThat(foundOrder)
+        .isPresent()
+        .get()
+        .satisfies(
+            order -> {
+              assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+              assertThat(order.getReadyAt()).isNull();
+              assertThat(order.getDeliveredAt()).isNull();
+              assertThat(order.getCancelledAt()).isEqualTo(occurredAt);
+            });
+  }
+
+  private void flushAndClear() {
+    entityManager.flush();
+    entityManager.clear();
   }
 
   private Order createOrderWithItems(UUID tenantId, int itemQuantity) {
@@ -202,6 +306,12 @@ class OrderServiceIntegrationTest {
     return command.items().stream()
         .map(CreateOrderItemCommand::productId)
         .collect(Collectors.toSet());
+  }
+
+  private Order createReadyOrder() {
+    var savedOrder = orderService.save(createOrderWithItems(TENANT_ID, 1));
+    orderService.markAsReady(TENANT_ID, savedOrder.getId());
+    return savedOrder;
   }
 
   private void assertOrderItemsMatchFixtures(Order order, List<OrderItemFixture> fixtures) {

--- a/src/test/java/br/com/f2e/ovenplatform/orders/domain/OrderTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/domain/OrderTest.java
@@ -3,7 +3,9 @@ package br.com.f2e.ovenplatform.orders.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import br.com.f2e.ovenplatform.orders.domain.exception.InvalidOrderStatusTransitionException;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -21,10 +23,15 @@ class OrderTest {
   @Test
   void shouldCreateOrderWithInitialState() {
 
-    assertThat(order().getTenantId()).isEqualTo(TENANT_ID);
-    assertThat(order().getStatus()).isEqualTo(OrderStatus.CREATED);
-    assertThat(order().getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
-    assertThat(order().getItems()).isEmpty();
+    Order order = order();
+
+    assertThat(order.getTenantId()).isEqualTo(TENANT_ID);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.CREATED);
+    assertThat(order.getTotalAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    assertThat(order.getReadyAt()).isNull();
+    assertThat(order.getDeliveredAt()).isNull();
+    assertThat(order.getCancelledAt()).isNull();
+    assertThat(order.getItems()).isEmpty();
   }
 
   @Test
@@ -87,6 +94,100 @@ class OrderTest {
     var items = order.getItems();
 
     assertThatThrownBy(items::clear).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCancellingReadyOrder() {
+    var readyAt = Instant.parse("2026-05-12T20:18:00Z");
+    var cancelledAt = Instant.parse("2026-05-12T20:30:00Z");
+
+    var order = order();
+    order.markAsReady(readyAt);
+
+    assertThatThrownBy(() -> order.cancel(cancelledAt))
+        .isInstanceOf(InvalidOrderStatusTransitionException.class)
+        .hasMessage(
+            "Cannot transition order from %s to %s."
+                .formatted(OrderStatus.READY, OrderStatus.CANCELLED));
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.READY);
+    assertThat(order.getReadyAt()).isEqualTo(readyAt);
+    assertThat(order.getCancelledAt()).isNull();
+  }
+
+  @Test
+  void shouldThrowExceptionWhenCancellingDeliveredOrder() {
+    var readyAt = Instant.parse("2026-05-12T20:18:00Z");
+    var deliveredAt = Instant.parse("2026-05-12T20:25:00Z");
+    var cancelledAt = Instant.parse("2026-05-12T20:30:00Z");
+
+    var order = order();
+    order.markAsReady(readyAt);
+    order.markAsDelivered(deliveredAt);
+
+    assertThatThrownBy(() -> order.cancel(cancelledAt))
+        .isInstanceOf(InvalidOrderStatusTransitionException.class)
+        .hasMessage(
+            "Cannot transition order from %s to %s."
+                .formatted(OrderStatus.DELIVERED, OrderStatus.CANCELLED));
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+    assertThat(order.getReadyAt()).isEqualTo(readyAt);
+    assertThat(order.getDeliveredAt()).isEqualTo(deliveredAt);
+    assertThat(order.getCancelledAt()).isNull();
+  }
+
+  @Test
+  void shouldKeepReadyTimestampWhenMarkingReadyOrderAsReadyAgain() {
+    var readyAt = Instant.parse("2026-05-12T20:18:00Z");
+    var secondAttemptAt = Instant.parse("2026-05-12T20:25:00Z");
+
+    var order = order();
+
+    order.markAsReady(readyAt);
+    order.markAsReady(secondAttemptAt);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.READY);
+    assertThat(order.getReadyAt()).isEqualTo(readyAt);
+    assertThat(order.getReadyAt()).isNotEqualTo(secondAttemptAt);
+    assertThat(order.getDeliveredAt()).isNull();
+    assertThat(order.getCancelledAt()).isNull();
+  }
+
+  @Test
+  void shouldKeepDeliveredTimestampWhenMarkingDeliveredOrderAsDeliveredAgain() {
+    var readyAt = Instant.parse("2026-05-12T20:18:00Z");
+    var deliveredAt = Instant.parse("2026-05-12T20:20:00Z");
+    var secondAttemptAt = Instant.parse("2026-05-12T20:25:00Z");
+
+    var order = order();
+
+    order.markAsReady(readyAt);
+    order.markAsDelivered(deliveredAt);
+    order.markAsDelivered(secondAttemptAt);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+    assertThat(order.getReadyAt()).isEqualTo(readyAt);
+    assertThat(order.getDeliveredAt()).isEqualTo(deliveredAt);
+    assertThat(order.getDeliveredAt()).isNotEqualTo(secondAttemptAt);
+    assertThat(order.getCancelledAt()).isNull();
+  }
+
+  @Test
+  void shouldKeepCancelledTimestampWhenMarkingCancelledOrderAsCancelledAgain() {
+    var cancelledAt = Instant.parse("2026-05-12T20:18:00Z");
+    var secondAttemptAt = Instant.parse("2026-05-12T20:25:00Z");
+
+    var order = order();
+
+    order.cancel(cancelledAt);
+    order.cancel(secondAttemptAt);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+    assertThat(order.getReadyAt()).isNull();
+    assertThat(order.getDeliveredAt()).isNull();
+    assertThat(order.getCancelledAt()).isEqualTo(cancelledAt);
+    assertThat(order.getCancelledAt()).isNotEqualTo(secondAttemptAt);
   }
 
   private static Stream<Arguments> invalidItems() {

--- a/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
@@ -1,17 +1,21 @@
 package br.com.f2e.ovenplatform.orders.infrastructure.web;
 
 import static br.com.f2e.ovenplatform.shared.infrastructure.persistence.test.EntityIdTestUtils.withId;
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.API_VERSION_HEADER;
+import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.API_VERSION_VALUE;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.ApiErrorResponseMatchers.expectValidationErrors;
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.test.LocationHeaderAssertions.assertLocationPath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,6 +24,8 @@ import br.com.f2e.ovenplatform.orders.application.CreateOrderCommand;
 import br.com.f2e.ovenplatform.orders.application.OrderService;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
+import br.com.f2e.ovenplatform.orders.domain.exception.InvalidOrderStatusTransitionException;
+import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
@@ -27,6 +33,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -180,6 +187,10 @@ class OrderControllerTest {
         .andExpect(jsonPath("$.tenantId").value(TENANT_ID.toString()))
         .andExpect(jsonPath("$.status").value(OrderStatus.CREATED.name()))
         .andExpect(jsonPath("$.totalAmount").value(75.90))
+        .andExpect(jsonPath("$.createdAt").isEmpty())
+        .andExpect(jsonPath("$.readyAt").isEmpty())
+        .andExpect(jsonPath("$.deliveredAt").isEmpty())
+        .andExpect(jsonPath("$.cancelledAt").isEmpty())
         .andExpect(jsonPath("$.items").isArray())
         .andExpect(jsonPath("$.items.length()").value(1))
         .andExpect(jsonPath("$.items[0].productId").value(PRODUCT_ID.toString()))
@@ -207,9 +218,7 @@ class OrderControllerTest {
     var invalidOrderId = "invalid-uuid";
 
     mockMvc
-        .perform(
-            get(BASE_URL + "/" + invalidOrderId)
-                .header(TENANT_ID_HEADER, TENANT_ID))
+        .perform(get(BASE_URL + "/" + invalidOrderId).header(TENANT_ID_HEADER, TENANT_ID))
         .andExpect(status().isBadRequest())
         .andExpectAll(
             expectValidationErrors(
@@ -222,6 +231,70 @@ class OrderControllerTest {
                 HttpStatus.BAD_REQUEST.value()));
 
     verifyNoInteractions(orderService);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("transitionEndpoints")
+  void shouldReturnNoContentForOrderTransitionEndpoints(
+      String endpoint, Consumer<OrderService> verification) throws Exception {
+    mockMvc
+        .perform(
+            post(BASE_URL + "/" + ORDER_ID + endpoint)
+                .header(TENANT_ID_HEADER, TENANT_ID)
+                .header(API_VERSION_HEADER, API_VERSION_VALUE))
+        .andExpect(status().isNoContent())
+        .andExpect(content().string(""));
+
+    verification.accept(verify(orderService));
+  }
+
+  @Test
+  void shouldReturn404WhenOrderDoesNotExistToBeMarkedAsReady() throws Exception {
+    var fullPath = BASE_URL + "/" + ORDER_ID + "/mark-ready";
+
+    doThrow(new ResourceNotFoundException("Order", ORDER_ID))
+        .when(orderService)
+        .markAsReady(TENANT_ID, ORDER_ID);
+
+    mockMvc
+        .perform(post(fullPath).header(TENANT_ID_HEADER, TENANT_ID))
+        .andExpect(status().isNotFound())
+        .andExpectAll(
+            expectValidationErrors(
+                HttpStatus.NOT_FOUND,
+                fullPath,
+                HttpStatus.NOT_FOUND.getReasonPhrase(),
+                ApiErrorCodes.RESOURCE_NOT_FOUND,
+                "Order id: %s not found".formatted(ORDER_ID),
+                null,
+                HttpStatus.NOT_FOUND.value()));
+
+    verify(orderService).markAsReady(TENANT_ID, ORDER_ID);
+  }
+
+  @Test
+  void shouldReturn409WhenCancellingReadyOrder() throws Exception {
+    var fullPath = BASE_URL + "/" + ORDER_ID + "/cancel";
+
+    doThrow(new InvalidOrderStatusTransitionException(OrderStatus.READY, OrderStatus.CANCELLED))
+        .when(orderService)
+        .cancel(TENANT_ID, ORDER_ID);
+
+    mockMvc
+        .perform(post(fullPath).header(TENANT_ID_HEADER, TENANT_ID))
+        .andExpect(status().isConflict())
+        .andExpectAll(
+            expectValidationErrors(
+                HttpStatus.CONFLICT,
+                fullPath,
+                HttpStatus.CONFLICT.getReasonPhrase(),
+                ApiErrorCodes.INVALID_ORDER_STATUS_TRANSITION,
+                "Cannot transition order from %s to %s."
+                    .formatted(OrderStatus.READY, OrderStatus.CANCELLED),
+                null,
+                HttpStatus.CONFLICT.value()));
+
+    verify(orderService).cancel(TENANT_ID, ORDER_ID);
   }
 
   private Order createOrder(
@@ -247,5 +320,17 @@ class OrderControllerTest {
             "items[0].quantity",
             "must be greater than 0",
             new CreateOrderRequest(List.of(new OrderItemRequest(UUID.randomUUID(), -1)))));
+  }
+
+  private static Stream<Arguments> transitionEndpoints() {
+    return Stream.of(
+        Arguments.of(
+            "/mark-ready",
+            (Consumer<OrderService>) service -> service.markAsReady(TENANT_ID, ORDER_ID)),
+        Arguments.of(
+            "/mark-delivered",
+            (Consumer<OrderService>) service -> service.markAsDelivered(TENANT_ID, ORDER_ID)),
+        Arguments.of(
+            "/cancel", (Consumer<OrderService>) service -> service.cancel(TENANT_ID, ORDER_ID)));
   }
 }


### PR DESCRIPTION
## Summary

Adds explicit operational status transitions to the Orders module, modeling the order lifecycle as domain behavior instead of direct status mutation.

This PR introduces the initial restaurant/pizzeria workflow:

- `CREATED -> READY`
- `CREATED -> CANCELLED`
- `READY -> DELIVERED`

It also treats `DELIVERED` and `CANCELLED` as final states and keeps repeated transition commands idempotent when the order is already in the target status.

## Business Value

Orders now have a controlled lifecycle that better represents a real restaurant operation.

This allows staff to mark orders as ready, delivered, or cancelled while preserving lifecycle timestamps for visibility and future operational metrics.

The implementation also prepares the Orders module for future improvements such as preparation tracking, domain events, outbox, retries, and idempotency support.

## What changed

- Added `READY`, `DELIVERED`, and `CANCELLED` order statuses
- Added domain behavior to `Order`:
  - `markAsReady(...)`
  - `markAsDelivered(...)`
  - `cancel(...)`
- Centralized valid status transitions in `OrderStatus`
- Added lifecycle timestamps:
  - `readyAt`
  - `deliveredAt`
  - `cancelledAt`
- Exposed lifecycle timestamps in `OrderResponse`
- Added transition endpoints:
  - `POST /orders/{id}/mark-ready`
  - `POST /orders/{id}/mark-delivered`
  - `POST /orders/{id}/cancel`
- Transition endpoints return `204 No Content` on success
- Added shared `ResourceNotFoundException`
- Added a module-specific `OrderExceptionHandler` for Orders-specific errors
- Added a shared `Clock` bean for deterministic time handling
- Moved JPA auditing config under shared infrastructure config
- Updated Orders changelog with nullable lifecycle timestamp columns

## Architecture Notes

- Transition rules remain inside the Orders domain model.
- `Order` remains the aggregate root responsible for applying transitions and lifecycle timestamps.
- `OrderStatus` knows which transitions are allowed, while `Order` executes the transition.
- Repeated commands for the same target status are treated as idempotent no-ops and do not overwrite the original lifecycle timestamp.
- Orders-specific exceptions are handled inside the Orders module to avoid making shared infrastructure depend on Orders internals.
- `Clock` is injected at the application service level and `Instant` is passed into the domain model.

## API Contract

### Mark order as ready

POST /orders/{id}/mark-ready
X-Tenant-Id: <tenant-id>
X-API-Version: 1.0

Response:

204 No Content

### Mark order as delivered

POST /orders/{id}/mark-delivered
X-Tenant-Id: <tenant-id>
X-API-Version: 1.0

Response:

204 No Content

### Cancel order

POST /orders/{id}/cancel
X-Tenant-Id: <tenant-id>
X-API-Version: 1.0

Response:

204 No Content

### Order response

Order read responses now include lifecycle timestamps:

{
  "id": "<order-id>",
  "tenantId": "<tenant-id>",
  "status": "READY",
  "totalAmount": 70.80,
  "createdAt": "2026-05-12T20:00:00Z",
  "readyAt": "2026-05-12T20:18:00Z",
  "deliveredAt": null,
  "cancelledAt": null,
  "items": [
    {
      "productId": "<product-id>",
      "quantity": 2,
      "unitPrice": 35.40,
      "subtotal": 70.80
    }
  ]
}

## Tests

Added/updated tests covering:

- valid domain transitions
- invalid domain transitions
- final status behavior
- idempotent repeated transition commands
- lifecycle timestamps not being overwritten by repeated commands
- successful service-level status transitions
- not found order during transition
- controller endpoints returning `204 No Content`
- controller handling `404 Not Found`
- controller handling `409 Conflict` for invalid transitions
- order read response including lifecycle timestamp fields

## Out of Scope

- `PREPARING` status
- preparation-time metrics based on `PREPARING`
- payment processing
- domain events
- outbox
- retry mechanism
- idempotency-key support
- optimistic locking or conditional database updates
- full audit/history of status changes
- order listing/pagination

Closes #23