### PR TITLE
feat(orders): add list orders API

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
@@ -6,6 +6,7 @@ import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENAN
 import br.com.f2e.ovenplatform.orders.application.OrderService;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.ResourceUriBuilder;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -67,5 +68,11 @@ public class OrderController {
       @RequestHeader(TENANT_ID_HEADER) UUID tenantId, @PathVariable UUID id) {
     orderService.cancel(tenantId, id);
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping(version = API_VERSION_VALUE)
+  public ResponseEntity<List<OrderResponse>> list(@RequestHeader(TENANT_ID_HEADER) UUID tenantId) {
+    var orders = orderService.listOrders(tenantId).stream().map(OrderResponse::from).toList();
+    return ResponseEntity.ok(orders);
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
@@ -297,6 +297,43 @@ class OrderControllerTest {
     verify(orderService).cancel(TENANT_ID, ORDER_ID);
   }
 
+  @Test
+  void shouldListOrdersByTenant() throws Exception {
+    var unitPrice = new BigDecimal("25.30");
+    var secondOrderId = UUID.randomUUID();
+
+    var orders =
+        List.of(
+            createOrder(TENANT_ID, ORDER_ID, PRODUCT_ID, 3, unitPrice),
+            createOrder(TENANT_ID, secondOrderId, PRODUCT_ID, 2, unitPrice));
+
+    when(orderService.listOrders(TENANT_ID)).thenReturn(orders);
+
+    var secondOrderJson = "$[1]";
+
+    mockMvc
+        .perform(get(BASE_URL).header(TENANT_ID_HEADER, TENANT_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(ORDER_ID.toString()))
+        .andExpect(jsonPath(secondOrderJson + ".id").value(secondOrderId.toString()))
+        .andExpect(jsonPath(secondOrderJson + ".tenantId").value(TENANT_ID.toString()))
+        .andExpect(jsonPath(secondOrderJson + ".status").value(OrderStatus.CREATED.name()))
+        .andExpect(jsonPath(secondOrderJson + ".totalAmount").value(50.60))
+        .andExpect(jsonPath(secondOrderJson + ".createdAt").isEmpty())
+        .andExpect(jsonPath(secondOrderJson + ".readyAt").isEmpty())
+        .andExpect(jsonPath(secondOrderJson + ".deliveredAt").isEmpty())
+        .andExpect(jsonPath(secondOrderJson + ".cancelledAt").isEmpty())
+        .andExpect(jsonPath(secondOrderJson + ".items").isArray())
+        .andExpect(jsonPath(secondOrderJson + ".items.length()").value(1))
+        .andExpect(jsonPath(secondOrderJson + ".items[0].productId").value(PRODUCT_ID.toString()))
+        .andExpect(jsonPath(secondOrderJson + ".items[0].quantity").value(2))
+        .andExpect(jsonPath(secondOrderJson + ".items[0].unitPrice").value(25.30))
+        .andExpect(jsonPath(secondOrderJson + ".items[0].subtotal").value(50.60));
+
+    verify(orderService).listOrders(TENANT_ID);
+  }
+
   private Order createOrder(
       UUID tenantId, UUID orderId, UUID productId, int quantity, BigDecimal unitPrice) {
     var order = withId(new Order(tenantId), orderId);


### PR DESCRIPTION
## Summary

Adds the initial list orders endpoint to the Orders module.

This PR completes the first operational API flow for Orders:

create → get by id → status transitions → list

The endpoint allows restaurant staff to retrieve all orders for a tenant, enabling visibility over current operations.

## Business Value

Listing orders provides a simple way for staff to monitor ongoing operations without accessing orders individually.

It enables visibility into:

- newly created orders
- orders ready for pickup
- delivered orders
- cancelled orders

This lays the foundation for future operational views such as kitchen queues, delivery queues, filtering, and pagination.

## What changed

- Added `GET /orders` endpoint
- Returns all orders for the provided `X-Tenant-Id`
- Reuses existing `OrderResponse` mapping
- Includes lifecycle timestamps (`createdAt`, `readyAt`, `deliveredAt`, `cancelledAt`)
- Includes order items in the response
- Returns `200 OK` with an array (empty if no orders)
- Added WebMvc test validating response structure and service delegation

## API Contract

GET /orders  
X-Tenant-Id: <tenant-id>  
X-API-Version: 1.0

Response:

200 OK

[
  {
    "id": "<order-id>",
    "tenantId": "<tenant-id>",
    "status": "CREATED",
    "totalAmount": 70.80,
    "createdAt": "2026-05-12T20:00:00Z",
    "readyAt": null,
    "deliveredAt": null,
    "cancelledAt": null,
    "items": [
      {
        "productId": "<product-id>",
        "quantity": 2,
        "unitPrice": 35.40,
        "subtotal": 70.80
      }
    ]
  }
]

## Architecture Notes

- Listing is tenant-scoped at the application service level
- Controller remains thin and delegates to `OrderService`
- Response reuses `OrderResponse` to keep consistency across endpoints
- No pagination or filtering added to keep the initial version simple and focused

## Tests

- Reused existing service/integration tests for tenant isolation and listing behavior
- Added WebMvc test for:
  - successful list response
  - response structure and mapping
  - service delegation

## Out of Scope

- Status filtering
- Pagination
- Sorting
- Advanced filtering (date, customer, etc.)
- Kitchen/delivery-specific views
- Reporting

Closes #24