### PR TITLE
feat(payment): capture payment info on order creation

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/CreateOrderCommand.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/CreateOrderCommand.java
@@ -2,7 +2,7 @@ package br.com.f2e.ovenplatform.orders.application;
 
 import java.util.List;
 
-public record CreateOrderCommand(List<CreateOrderItemCommand> items) {
+public record CreateOrderCommand(List<CreateOrderItemCommand> items, PaymentInfo paymentInfo) {
 
   public CreateOrderCommand {
     items = List.copyOf(items);

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentMethod.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentMethod.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+public enum OrderPaymentMethod {
+  CASH,
+  CARD
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentStatus.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentStatus.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+public enum OrderPaymentStatus {
+  PAID,
+  PENDING
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPlacedEvent.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPlacedEvent.java
@@ -1,0 +1,11 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record OrderPlacedEvent(
+    UUID tenantId,
+    UUID orderId,
+    OrderPaymentMethod paymentMethod,
+    OrderPaymentStatus paymentStatus,
+    BigDecimal totalAmount) {}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,14 +20,17 @@ public class OrderService {
   private final OrderRepository orderRepository;
   private final OrderableProductProvider orderableProductProvider;
   private final Clock clock;
+  private final ApplicationEventPublisher eventPublisher;
 
   public OrderService(
       OrderRepository orderRepository,
       OrderableProductProvider orderableProductProvider,
-      Clock clock) {
+      Clock clock,
+      ApplicationEventPublisher eventPublisher) {
     this.orderRepository = orderRepository;
     this.orderableProductProvider = orderableProductProvider;
     this.clock = clock;
+    this.eventPublisher = eventPublisher;
   }
 
   public Order save(Order order) {
@@ -59,7 +63,17 @@ public class OrderService {
               order.addItem(item.productId(), item.quantity(), unitPrice);
             });
 
-    return orderRepository.save(order);
+    var savedOrder = orderRepository.save(order);
+
+    eventPublisher.publishEvent(
+        new OrderPlacedEvent(
+            savedOrder.getTenantId(),
+            savedOrder.getId(),
+            orderCommand.paymentInfo().method(),
+            orderCommand.paymentInfo().status(),
+            savedOrder.getTotalAmount()));
+
+    return savedOrder;
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/PaymentInfo.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/PaymentInfo.java
@@ -1,0 +1,10 @@
+package br.com.f2e.ovenplatform.orders.application;
+
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requireNotNull;
+
+public record PaymentInfo(OrderPaymentMethod method, OrderPaymentStatus status) {
+  public PaymentInfo {
+    requireNotNull(method, "payment method");
+    requireNotNull(status, "payment status");
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
@@ -4,6 +4,8 @@ import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.API_V
 import static br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders.TENANT_ID_HEADER;
 
 import br.com.f2e.ovenplatform.orders.application.OrderService;
+import br.com.f2e.ovenplatform.orders.infrastructure.web.dto.CreateOrderRequest;
+import br.com.f2e.ovenplatform.orders.infrastructure.web.dto.OrderResponse;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.ResourceUriBuilder;
 import jakarta.validation.Valid;
 import java.util.List;

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/CreateOrderRequest.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/CreateOrderRequest.java
@@ -1,6 +1,7 @@
-package br.com.f2e.ovenplatform.orders.infrastructure.web;
+package br.com.f2e.ovenplatform.orders.infrastructure.web.dto;
 
 import br.com.f2e.ovenplatform.orders.application.CreateOrderCommand;
+import br.com.f2e.ovenplatform.orders.application.PaymentInfo;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -15,9 +16,11 @@ public record CreateOrderRequest(
     @NotNull(message = "must not be null")
         @Size(min = 1, message = "items must have at least 1 item")
         @Valid
-        List<OrderItemRequest> items) {
+        List<OrderItemRequest> items,
+    @NotNull @Valid PaymentInfo paymentInfo) {
 
   public CreateOrderCommand toCommand() {
-    return new CreateOrderCommand(items.stream().map(OrderItemRequest::toCommand).toList());
+    return new CreateOrderCommand(
+        items.stream().map(OrderItemRequest::toCommand).toList(), paymentInfo);
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/OrderItemRequest.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/OrderItemRequest.java
@@ -1,4 +1,4 @@
-package br.com.f2e.ovenplatform.orders.infrastructure.web;
+package br.com.f2e.ovenplatform.orders.infrastructure.web.dto;
 
 import br.com.f2e.ovenplatform.orders.application.CreateOrderItemCommand;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/OrderItemResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/OrderItemResponse.java
@@ -1,4 +1,4 @@
-package br.com.f2e.ovenplatform.orders.infrastructure.web;
+package br.com.f2e.ovenplatform.orders.infrastructure.web.dto;
 
 import br.com.f2e.ovenplatform.orders.domain.OrderItem;
 import java.math.BigDecimal;

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/OrderResponse.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/dto/OrderResponse.java
@@ -1,4 +1,4 @@
-package br.com.f2e.ovenplatform.orders.infrastructure.web;
+package br.com.f2e.ovenplatform.orders.infrastructure.web.dto;
 
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;

--- a/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
@@ -26,11 +26,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @Import({OrderService.class, JpaOrderRepositoryAdapter.class})
 @EnableJpaAuditing
+@RecordApplicationEvents
 class OrderServiceIntegrationTest {
 
   private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
@@ -48,7 +51,11 @@ class OrderServiceIntegrationTest {
   @MockitoBean
   private OrderableProductProvider orderableProductProvider;
 
-  @MockitoBean private Clock clock;
+  @SuppressWarnings("unused")
+  @MockitoBean
+  private Clock clock;
+
+  @Autowired private ApplicationEvents applicationEvents;
 
   @Test
   void shouldCreateOrderWithItemsUsingOrderableProductPrices() {
@@ -72,6 +79,17 @@ class OrderServiceIntegrationTest {
     assertOrderItemsMatchFixtures(order, fixtures);
 
     verify(orderableProductProvider).findOrderableProducts(TENANT_ID, productIds);
+
+    var orderPlacedEvents = applicationEvents.stream(OrderPlacedEvent.class).toList();
+
+    assertThat(orderPlacedEvents).hasSize(1);
+
+    var orderPlacedEvent = orderPlacedEvents.getFirst();
+
+    assertThat(orderPlacedEvent.orderId()).isEqualTo(order.getId());
+    assertThat(orderPlacedEvent.paymentMethod()).isEqualTo(OrderPaymentMethod.CASH);
+    assertThat(orderPlacedEvent.paymentStatus()).isEqualTo(OrderPaymentStatus.PAID);
+    assertThat(orderPlacedEvent.totalAmount()).isEqualByComparingTo(order.getTotalAmount());
   }
 
   @Test
@@ -163,8 +181,9 @@ class OrderServiceIntegrationTest {
   @Test
   void shouldThrowExceptionWhenCatalogReturnNullProduct() {
     var productId = UUID.randomUUID();
+    var paymentInfo = new PaymentInfo(OrderPaymentMethod.CASH, OrderPaymentStatus.PAID);
     CreateOrderCommand orderCommand =
-        new CreateOrderCommand(List.of(new CreateOrderItemCommand(productId, 1)));
+        new CreateOrderCommand(List.of(new CreateOrderItemCommand(productId, 1)), paymentInfo);
     assertThatThrownBy(() -> orderService.createOrder(TENANT_ID, orderCommand))
         .isInstanceOf(ProductNotAvailableForOrderingException.class)
         .hasMessage("Product is not available for ordering: %s".formatted(productId));
@@ -295,7 +314,9 @@ class OrderServiceIntegrationTest {
   }
 
   private CreateOrderCommand createOrderCommand(List<OrderItemFixture> fixtures) {
-    return new CreateOrderCommand(fixtures.stream().map(OrderItemFixture::command).toList());
+    var paymentInfo = new PaymentInfo(OrderPaymentMethod.CASH, OrderPaymentStatus.PAID);
+    return new CreateOrderCommand(
+        fixtures.stream().map(OrderItemFixture::command).toList(), paymentInfo);
   }
 
   private List<OrderableProduct> createOrderableProducts(List<OrderItemFixture> fixtures) {

--- a/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
@@ -21,15 +21,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import br.com.f2e.ovenplatform.identity.infrastructure.security.JwtService;
 import br.com.f2e.ovenplatform.orders.application.CreateOrderCommand;
+import br.com.f2e.ovenplatform.orders.application.OrderPaymentMethod;
+import br.com.f2e.ovenplatform.orders.application.OrderPaymentStatus;
 import br.com.f2e.ovenplatform.orders.application.OrderService;
+import br.com.f2e.ovenplatform.orders.application.PaymentInfo;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
 import br.com.f2e.ovenplatform.orders.domain.exception.InvalidOrderStatusTransitionException;
+import br.com.f2e.ovenplatform.orders.infrastructure.web.dto.CreateOrderRequest;
+import br.com.f2e.ovenplatform.orders.infrastructure.web.dto.OrderItemRequest;
 import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -42,6 +48,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -61,10 +68,11 @@ class OrderControllerTest {
 
   @MockitoBean private OrderService orderService;
   @MockitoBean private JwtService jwtService;
+  @MockitoBean private ApplicationEventPublisher eventPublisher;
 
   @Test
   void shouldCreateOrderWithItems() throws Exception {
-    var orderRequest = new CreateOrderRequest(List.of(new OrderItemRequest(PRODUCT_ID, 3)));
+    var orderRequest = createOrderRequest(PRODUCT_ID, 3);
 
     var order = createOrder(TENANT_ID, ORDER_ID, PRODUCT_ID, 3, new BigDecimal("35.40"));
 
@@ -101,11 +109,14 @@ class OrderControllerTest {
     assertThat(command.items()).hasSize(1);
     assertThat(command.items().getFirst().productId()).isEqualTo(PRODUCT_ID);
     assertThat(command.items().getFirst().quantity()).isEqualTo(3);
+    assertThat(command.paymentInfo()).isNotNull();
+    assertThat(command.paymentInfo().method()).isEqualTo(OrderPaymentMethod.CASH);
+    assertThat(command.paymentInfo().status()).isEqualTo(OrderPaymentStatus.PAID);
   }
 
   @Test
   void shouldReturnBadRequestWhenTenantHeaderIsMissing() throws Exception {
-    var orderRequest = new CreateOrderRequest(List.of(new OrderItemRequest(PRODUCT_ID, 3)));
+    var orderRequest = createOrderRequest(PRODUCT_ID, 3);
     mockMvc
         .perform(
             post(BASE_URL)
@@ -127,7 +138,7 @@ class OrderControllerTest {
 
   @Test
   void shouldReturnBadRequestWhenTenantHeaderIsInvalid() throws Exception {
-    var orderRequest = new CreateOrderRequest(List.of(new OrderItemRequest(PRODUCT_ID, 3)));
+    var orderRequest = createOrderRequest(PRODUCT_ID, 3);
     mockMvc
         .perform(
             post(BASE_URL)
@@ -343,20 +354,16 @@ class OrderControllerTest {
 
   private static Stream<Arguments> invalidCreateOrderRequests() {
     return Stream.of(
-        Arguments.of("items", "must not be null", new CreateOrderRequest(null)),
-        Arguments.of("items", "items must have at least 1 item", new CreateOrderRequest(List.of())),
+        Arguments.of("items", "must not be null", createOrderRequest(null)),
         Arguments.of(
-            "items[0].productId",
-            "must not be null",
-            new CreateOrderRequest(List.of(new OrderItemRequest(null, 1)))),
+            "items",
+            "items must have at least 1 item",
+            createOrderRequest(Collections.emptyList())),
+        Arguments.of("items[0].productId", "must not be null", createOrderRequest(null, 1)),
         Arguments.of(
-            "items[0].quantity",
-            "must be greater than 0",
-            new CreateOrderRequest(List.of(new OrderItemRequest(UUID.randomUUID(), 0)))),
+            "items[0].quantity", "must be greater than 0", createOrderRequest(PRODUCT_ID, 0)),
         Arguments.of(
-            "items[0].quantity",
-            "must be greater than 0",
-            new CreateOrderRequest(List.of(new OrderItemRequest(UUID.randomUUID(), -1)))));
+            "items[0].quantity", "must be greater than 0", createOrderRequest(PRODUCT_ID, -1)));
   }
 
   private static Stream<Arguments> transitionEndpoints() {
@@ -369,5 +376,16 @@ class OrderControllerTest {
             (Consumer<OrderService>) service -> service.markAsDelivered(TENANT_ID, ORDER_ID)),
         Arguments.of(
             "/cancel", (Consumer<OrderService>) service -> service.cancel(TENANT_ID, ORDER_ID)));
+  }
+
+  private static CreateOrderRequest createOrderRequest(UUID productId, int quantity) {
+    return new CreateOrderRequest(
+        List.of(new OrderItemRequest(productId, quantity)),
+        new PaymentInfo(OrderPaymentMethod.CASH, OrderPaymentStatus.PAID));
+  }
+
+  private static CreateOrderRequest createOrderRequest(List<OrderItemRequest> items) {
+    return new CreateOrderRequest(
+        items, new PaymentInfo(OrderPaymentMethod.CASH, OrderPaymentStatus.PAID));
   }
 }


### PR DESCRIPTION
## Summary

Updates order creation to capture initial payment information as part of the normal cashier/operator flow.

Every order now carries payment information at creation time, indicating whether the payment starts as `PAID` or `PENDING`, without accepting payment amount from the frontend.

## Business Value

Restaurant staff can register the order and its initial payment situation in a single flow.

This supports common real-world scenarios such as:

- customer pays immediately at the cashier
- customer places an order by phone and pays on delivery
- future integrations sending orders with payment context

This also prepares the Orders module to publish the data needed by the future Payments module.

## What changed

- Added payment information to order creation
- Added application-level payment info types:
  - `PaymentInfo`
  - `OrderPaymentMethod`
  - `OrderPaymentStatus`
- Updated `CreateOrderCommand` to include payment info
- Updated `CreateOrderRequest` to require `paymentInfo`
- Moved order web request/response DTOs into `orders.infrastructure.web.dto`
- Added `OrderPlacedEvent`
- Updated `OrderService#createOrder` to publish `OrderPlacedEvent`
- Kept payment amount owned by Orders through the calculated order total
- Kept `OrderResponse` unchanged

## Design Notes

- `paymentInfo` is required for order creation in the MVP.
- The frontend provides payment method and initial payment status only.
- The frontend does not send payment amount.
- Orders continues to calculate `totalAmount` from product/catalog data.
- `OrderPlacedEvent` carries:
  - tenantId
  - orderId
  - totalAmount
  - payment method
  - initial payment status
- This PR does not create or persist a Payment.
- Payments will consume this event in a future issue.

## API Contract

POST /orders  
X-Tenant-Id: <tenant-id>  
X-API-Version: 1.0

Request:
```
{
  "items": [
    {
      "productId": "<product-id>",
      "quantity": 2
    }
  ],
  "paymentInfo": {
    "method": "CASH",
    "status": "PENDING"
  }
}
```
For payments received immediately:
```
{
  "items": [
    {
      "productId": "<product-id>",
      "quantity": 2
    }
  ],
  "paymentInfo": {
    "method": "CASH",
    "status": "PAID"
  }
}
```
Response remains the existing order response shape.

## Tests

Added/updated coverage for:

- order creation request including `paymentInfo`
- mapping `paymentInfo` into `CreateOrderCommand`
- order creation still using backend/catalog prices
- publishing `OrderPlacedEvent`
- event carrying calculated order total
- event carrying payment method and initial payment status

## Out of Scope

- Creating the Payments module
- Persisting Payment
- Consuming `OrderPlacedEvent`
- Marking pending payment as paid
- External payment providers
- Payment retries
- Idempotency
- Partial payments
- Multiple payments per order
- Refunds
- Webhooks
- Automatically updating order status from payment status

Closes #77