### PR TITLE
feat(payments): register payment from order event

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentMethod.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentMethod.java
@@ -1,6 +1,0 @@
-package br.com.f2e.ovenplatform.orders.application;
-
-public enum OrderPaymentMethod {
-  CASH,
-  CARD
-}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentStatus.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderPaymentStatus.java
@@ -1,6 +1,0 @@
-package br.com.f2e.ovenplatform.orders.application;
-
-public enum OrderPaymentStatus {
-  PAID,
-  PENDING
-}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
@@ -1,5 +1,6 @@
 package br.com.f2e.ovenplatform.orders.application;
 
+import br.com.f2e.ovenplatform.orders.application.event.OrderPlacedEvent;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import java.time.Clock;

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/PaymentInfo.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/PaymentInfo.java
@@ -2,6 +2,9 @@ package br.com.f2e.ovenplatform.orders.application;
 
 import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requireNotNull;
 
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMethod;
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentStatus;
+
 public record PaymentInfo(OrderPaymentMethod method, OrderPaymentStatus status) {
   public PaymentInfo {
     requireNotNull(method, "payment method");

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPaymentMethod.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPaymentMethod.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.orders.application.event;
+
+public enum OrderPaymentMethod {
+  CASH,
+  CARD
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPaymentStatus.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPaymentStatus.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.orders.application.event;
+
+public enum OrderPaymentStatus {
+  PAID,
+  PENDING
+}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPlacedEvent.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPlacedEvent.java
@@ -1,4 +1,4 @@
-package br.com.f2e.ovenplatform.orders.application;
+package br.com.f2e.ovenplatform.orders.application.event;
 
 import java.math.BigDecimal;
 import java.util.UUID;

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/event/package-info.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/event/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("event")
+package br.com.f2e.ovenplatform.orders.application.event;

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentRepository.java
@@ -1,0 +1,12 @@
+package br.com.f2e.ovenplatform.payment.application;
+
+import br.com.f2e.ovenplatform.payment.domain.Payment;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentRepository {
+
+  Payment save(Payment payment);
+
+  Optional<Payment> findByTenantIdAndOrderId(UUID tenantId, UUID orderId);
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentService.java
@@ -1,0 +1,48 @@
+package br.com.f2e.ovenplatform.payment.application;
+
+import br.com.f2e.ovenplatform.payment.domain.Payment;
+import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentService {
+
+  private final PaymentRepository paymentRepository;
+  private final Clock clock;
+
+  public PaymentService(PaymentRepository paymentRepository, Clock clock) {
+    this.paymentRepository = paymentRepository;
+    this.clock = clock;
+  }
+
+  public void registerPaymentFromOrder(RegisterPaymentCommand paymentCommand) {
+    var payment =
+        switch (paymentCommand.paymentStatus()) {
+          case PAID ->
+              Payment.paid(
+                  paymentCommand.tenantId(),
+                  paymentCommand.orderId(),
+                  paymentCommand.amount(),
+                  paymentCommand.paymentMethod(),
+                  clock.instant());
+          case PENDING ->
+              Payment.pending(
+                  paymentCommand.tenantId(),
+                  paymentCommand.orderId(),
+                  paymentCommand.amount(),
+                  paymentCommand.paymentMethod());
+        };
+    paymentRepository.save(payment);
+  }
+
+  public Payment findByTenantIdAndOrderId(UUID tenantId, UUID orderId) {
+    return paymentRepository
+        .findByTenantIdAndOrderId(tenantId, orderId)
+        .orElseThrow(
+            () ->
+                new ResourceNotFoundException(
+                    "Payment for order id: %s not found".formatted(orderId)));
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/RegisterPaymentCommand.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/RegisterPaymentCommand.java
@@ -1,0 +1,25 @@
+package br.com.f2e.ovenplatform.payment.application;
+
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requireNotNull;
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requirePositive;
+
+import br.com.f2e.ovenplatform.payment.domain.PaymentMethod;
+import br.com.f2e.ovenplatform.payment.domain.PaymentStatus;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record RegisterPaymentCommand(
+    UUID tenantId,
+    UUID orderId,
+    BigDecimal amount,
+    PaymentMethod paymentMethod,
+    PaymentStatus paymentStatus) {
+
+  public RegisterPaymentCommand {
+    requireNotNull(tenantId, "tenantId");
+    requireNotNull(orderId, "orderId");
+    requirePositive(amount, "amount");
+    requireNotNull(paymentMethod, "paymentMethod");
+    requireNotNull(paymentStatus, "paymentStatus");
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/domain/Payment.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/domain/Payment.java
@@ -1,0 +1,91 @@
+package br.com.f2e.ovenplatform.payment.domain;
+
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requireNotNull;
+import static br.com.f2e.ovenplatform.shared.domain.validation.Preconditions.requirePositive;
+
+import br.com.f2e.ovenplatform.shared.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "payments")
+public class Payment extends BaseEntity {
+
+  @Column(nullable = false)
+  private UUID tenantId;
+
+  @Column(nullable = false)
+  private UUID orderId;
+
+  @Column(nullable = false, precision = 19, scale = 2)
+  private BigDecimal amount;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "method", nullable = false)
+  private PaymentMethod paymentMethod;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private PaymentStatus paymentStatus;
+
+  @Column(name = "paid_at")
+  private Instant paidAt;
+
+  protected Payment() {}
+
+  private Payment(
+      UUID tenantId,
+      UUID orderId,
+      BigDecimal amount,
+      PaymentMethod paymentMethod,
+      PaymentStatus paymentStatus,
+      Instant paidAt) {
+    this.tenantId = requireNotNull(tenantId, "tenantId");
+    this.orderId = requireNotNull(orderId, "orderId");
+    this.amount = requirePositive(amount, "amount");
+    this.paymentMethod = requireNotNull(paymentMethod, "paymentMethod");
+    this.paymentStatus = requireNotNull(paymentStatus, "paymentStatus");
+    this.paidAt = paidAt;
+  }
+
+  public static Payment paid(
+      UUID tenantId, UUID orderId, BigDecimal amount, PaymentMethod paymentMethod, Instant paidAt) {
+    requireNotNull(paidAt, "paidAt");
+    return new Payment(tenantId, orderId, amount, paymentMethod, PaymentStatus.PAID, paidAt);
+  }
+
+  public static Payment pending(
+      UUID tenantId, UUID orderId, BigDecimal amount, PaymentMethod paymentMethod) {
+    return new Payment(tenantId, orderId, amount, paymentMethod, PaymentStatus.PENDING, null);
+  }
+
+  public UUID getTenantId() {
+    return tenantId;
+  }
+
+  public UUID getOrderId() {
+    return orderId;
+  }
+
+  public BigDecimal getAmount() {
+    return amount;
+  }
+
+  public PaymentMethod getPaymentMethod() {
+    return paymentMethod;
+  }
+
+  public PaymentStatus getPaymentStatus() {
+    return paymentStatus;
+  }
+
+  public Instant getPaidAt() {
+    return paidAt;
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/domain/PaymentMethod.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/domain/PaymentMethod.java
@@ -1,0 +1,7 @@
+package br.com.f2e.ovenplatform.payment.domain;
+
+public enum PaymentMethod {
+  CASH,
+  CARD,
+  PIX
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/domain/PaymentStatus.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/domain/PaymentStatus.java
@@ -1,0 +1,6 @@
+package br.com.f2e.ovenplatform.payment.domain;
+
+public enum PaymentStatus {
+  PENDING,
+  PAID
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/event/OrderPlacedEventListener.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/event/OrderPlacedEventListener.java
@@ -1,0 +1,41 @@
+package br.com.f2e.ovenplatform.payment.infrastructure.event;
+
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMethod;
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentStatus;
+import br.com.f2e.ovenplatform.orders.application.event.OrderPlacedEvent;
+import br.com.f2e.ovenplatform.payment.application.PaymentService;
+import br.com.f2e.ovenplatform.payment.application.RegisterPaymentCommand;
+import br.com.f2e.ovenplatform.payment.domain.PaymentMethod;
+import br.com.f2e.ovenplatform.payment.domain.PaymentStatus;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderPlacedEventListener {
+
+  private final PaymentService paymentService;
+
+  public OrderPlacedEventListener(PaymentService paymentService) {
+    this.paymentService = paymentService;
+  }
+
+  @ApplicationModuleListener
+  void on(OrderPlacedEvent event) {
+    var command =
+        new RegisterPaymentCommand(
+            event.tenantId(),
+            event.orderId(),
+            event.totalAmount(),
+            toPaymentMethod(event.paymentMethod()),
+            toPaymentStatus(event.paymentStatus()));
+    paymentService.registerPaymentFromOrder(command);
+  }
+
+  private static PaymentStatus toPaymentStatus(OrderPaymentStatus status) {
+    return PaymentStatus.valueOf(status.name());
+  }
+
+  private static PaymentMethod toPaymentMethod(OrderPaymentMethod method) {
+    return PaymentMethod.valueOf(method.name());
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/persistence/JpaPaymentRepositoryAdapter.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/persistence/JpaPaymentRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package br.com.f2e.ovenplatform.payment.infrastructure.persistence;
+
+import br.com.f2e.ovenplatform.payment.application.PaymentRepository;
+import br.com.f2e.ovenplatform.payment.domain.Payment;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaPaymentRepositoryAdapter implements PaymentRepository {
+
+  private final SpringDataPaymentRepository paymentRepository;
+
+  public JpaPaymentRepositoryAdapter(SpringDataPaymentRepository paymentRepository) {
+    this.paymentRepository = paymentRepository;
+  }
+
+  @Override
+  public Payment save(Payment payment) {
+    return paymentRepository.save(payment);
+  }
+
+  @Override
+  public Optional<Payment> findByTenantIdAndOrderId(UUID tenantId, UUID orderId) {
+    return paymentRepository.findByTenantIdAndOrderId(tenantId, orderId);
+  }
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/persistence/SpringDataPaymentRepository.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/persistence/SpringDataPaymentRepository.java
@@ -1,0 +1,11 @@
+package br.com.f2e.ovenplatform.payment.infrastructure.persistence;
+
+import br.com.f2e.ovenplatform.payment.domain.Payment;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataPaymentRepository extends JpaRepository<Payment, UUID> {
+
+  Optional<Payment> findByTenantIdAndOrderId(UUID tenantId, UUID orderId);
+}

--- a/src/main/java/br/com/f2e/ovenplatform/shared/application/exception/ResourceNotFoundException.java
+++ b/src/main/java/br/com/f2e/ovenplatform/shared/application/exception/ResourceNotFoundException.java
@@ -7,4 +7,8 @@ public class ResourceNotFoundException extends RuntimeException {
   public ResourceNotFoundException(String resource, UUID id) {
     super("%s id: %s not found".formatted(resource, id));
   }
+
+  public ResourceNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/resources/db/changelog/changes/db.changelog-005-create-payments-table.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-005-create-payments-table.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="005-create-payments-table" author="franklin">
+        <createTable tableName="payments">
+            <column name="id" type="UUID">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="tenant_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="order_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="amount" type="NUMERIC(19,2)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="payment_method" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="payment_status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="paid_at" type="TIMESTAMP WITH TIME ZONE"/>
+
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createIndex indexName="idx_payments_tenant_id" tableName="payments">
+            <column name="tenant_id"/>
+        </createIndex>
+
+        <createIndex indexName="idx_payments_tenant_id_order_id" tableName="payments">
+            <column name="tenant_id"/>
+            <column name="order_id"/>
+        </createIndex>
+
+        <addUniqueConstraint
+                tableName="payments"
+                columnNames="tenant_id, order_id"
+                constraintName="uk_payments_tenant_id_order_id"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -10,5 +10,6 @@
     <include file="db/changelog/changes/db.changelog-002create-users.xml"/>
     <include file="db/changelog/changes/db.changelog-003create-products.xml"/>
     <include file="db/changelog/changes/db.changelog-004-create-orders-and-order-items-tables.xml"/>
+    <include file="db/changelog/changes/db.changelog-005-create-payments-table.xml" />
 
 </databaseChangeLog>

--- a/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMethod;
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentStatus;
+import br.com.f2e.ovenplatform.orders.application.event.OrderPlacedEvent;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
 import br.com.f2e.ovenplatform.orders.infrastructure.persistence.JpaOrderRepositoryAdapter;

--- a/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
@@ -21,10 +21,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import br.com.f2e.ovenplatform.identity.infrastructure.security.JwtService;
 import br.com.f2e.ovenplatform.orders.application.CreateOrderCommand;
-import br.com.f2e.ovenplatform.orders.application.OrderPaymentMethod;
-import br.com.f2e.ovenplatform.orders.application.OrderPaymentStatus;
 import br.com.f2e.ovenplatform.orders.application.OrderService;
 import br.com.f2e.ovenplatform.orders.application.PaymentInfo;
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMethod;
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentStatus;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.orders.domain.OrderStatus;
 import br.com.f2e.ovenplatform.orders.domain.exception.InvalidOrderStatusTransitionException;

--- a/src/test/java/br/com/f2e/ovenplatform/payment/application/PaymentServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/payment/application/PaymentServiceIntegrationTest.java
@@ -1,0 +1,100 @@
+package br.com.f2e.ovenplatform.payment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import br.com.f2e.ovenplatform.payment.domain.PaymentMethod;
+import br.com.f2e.ovenplatform.payment.domain.PaymentStatus;
+import br.com.f2e.ovenplatform.payment.infrastructure.persistence.JpaPaymentRepositoryAdapter;
+import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({PaymentService.class, JpaPaymentRepositoryAdapter.class})
+@EnableJpaAuditing
+class PaymentServiceIntegrationTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
+  private static final UUID ORDER_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecd");
+  private static final BigDecimal PAYMENT_AMOUNT = new BigDecimal("20.00");
+  private static final Instant PAID_AT = Instant.parse("2026-05-12T20:18:00Z");
+
+  @Autowired private PaymentService paymentService;
+  @Autowired private JpaPaymentRepositoryAdapter paymentRepository;
+  @Autowired private EntityManager entityManager;
+
+  @SuppressWarnings("unused")
+  @MockitoBean
+  private Clock clock;
+
+  @Test
+  void shouldRegisterPaidPayment() {
+
+    when(clock.instant()).thenReturn(PAID_AT);
+
+    paymentService.registerPaymentFromOrder(
+        new RegisterPaymentCommand(
+            TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH, PaymentStatus.PAID));
+
+    flushAndClear();
+
+    var payment = paymentRepository.findByTenantIdAndOrderId(TENANT_ID, ORDER_ID).orElseThrow();
+
+    assertThat(payment.getTenantId()).isEqualTo(TENANT_ID);
+    assertThat(payment.getOrderId()).isEqualTo(ORDER_ID);
+    assertThat(payment.getAmount()).isEqualByComparingTo("20.00");
+    assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.PAID);
+    assertThat(payment.getPaidAt()).isEqualTo(PAID_AT);
+
+    verify(clock).instant();
+  }
+
+  @Test
+  void shouldRegisterPendingPayment() {
+
+    paymentService.registerPaymentFromOrder(
+        new RegisterPaymentCommand(
+            TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH, PaymentStatus.PENDING));
+
+    flushAndClear();
+
+    var payment = paymentRepository.findByTenantIdAndOrderId(TENANT_ID, ORDER_ID).orElseThrow();
+
+    assertThat(payment.getTenantId()).isEqualTo(TENANT_ID);
+    assertThat(payment.getOrderId()).isEqualTo(ORDER_ID);
+    assertThat(payment.getAmount()).isEqualByComparingTo("20.00");
+    assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
+    assertThat(payment.getPaidAt()).isNull();
+
+    verifyNoInteractions(clock);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenResourceNotFound() {
+    assertThatThrownBy(() -> paymentService.findByTenantIdAndOrderId(TENANT_ID, ORDER_ID))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessage("Payment for order id: %s not found".formatted(ORDER_ID));
+  }
+
+  private void flushAndClear() {
+    entityManager.flush();
+    entityManager.clear();
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/payment/domain/PaymentTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/payment/domain/PaymentTest.java
@@ -1,0 +1,106 @@
+package br.com.f2e.ovenplatform.payment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PaymentTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
+  private static final UUID ORDER_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecd");
+  private static final BigDecimal PAYMENT_AMOUNT = new BigDecimal("20.00");
+  private static final Instant PAID_AT = Instant.parse("2026-05-12T20:18:00Z");
+
+  @Test
+  void shouldCreatePaidPaymentWithPaidAt() {
+
+    var paymentPaid =
+        Payment.paid(TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH, PAID_AT);
+
+    assertThat(paymentPaid.getTenantId()).isEqualTo(TENANT_ID);
+    assertThat(paymentPaid.getOrderId()).isEqualTo(ORDER_ID);
+    assertThat(paymentPaid.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(paymentPaid.getPaidAt()).isEqualTo(PAID_AT);
+    assertThat(paymentPaid.getPaymentStatus()).isEqualTo(PaymentStatus.PAID);
+    assertThat(paymentPaid.getAmount()).isEqualByComparingTo("20.00");
+  }
+
+  @Test
+  void shouldRejectPaidPaymentWithoutPaidAt() {
+    assertThatThrownBy(
+            () -> Payment.paid(TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("paidAt must not be null");
+  }
+
+  @Test
+  void shouldCreatePendingPaymentWithoutPaidAt() {
+
+    var pendingPayment = Payment.pending(TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH);
+
+    assertThat(pendingPayment.getTenantId()).isEqualTo(TENANT_ID);
+    assertThat(pendingPayment.getOrderId()).isEqualTo(ORDER_ID);
+    assertThat(pendingPayment.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(pendingPayment.getPaidAt()).isNull();
+    assertThat(pendingPayment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
+    assertThat(pendingPayment.getAmount()).isEqualByComparingTo("20.00");
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidPaidPayments")
+  void shouldRejectRequiredFields(
+      UUID tenantId,
+      UUID orderId,
+      BigDecimal paymentAmount,
+      PaymentMethod paymentMethod,
+      Instant paidAt,
+      String expectedMessage) {
+    assertThatThrownBy(() -> Payment.paid(tenantId, orderId, paymentAmount, paymentMethod, paidAt))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(expectedMessage);
+  }
+
+  private static Stream<Arguments> invalidPaidPayments() {
+    return Stream.of(
+        Arguments.of(
+            null,
+            ORDER_ID,
+            PAYMENT_AMOUNT,
+            PaymentMethod.CASH,
+            PAID_AT,
+            "tenantId must not be null"),
+        Arguments.of(
+            TENANT_ID,
+            null,
+            PAYMENT_AMOUNT,
+            PaymentMethod.CASH,
+            PAID_AT,
+            "orderId must not be null"),
+        Arguments.of(
+            TENANT_ID,
+            ORDER_ID,
+            BigDecimal.ZERO,
+            PaymentMethod.CASH,
+            PAID_AT,
+            "amount must be greater than zero"),
+        Arguments.of(
+            TENANT_ID, ORDER_ID, null, PaymentMethod.CASH, PAID_AT, "amount must not be null"),
+        Arguments.of(
+            TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, null, PAID_AT, "paymentMethod must not be null"),
+        Arguments.of(
+            TENANT_ID,
+            ORDER_ID,
+            PAYMENT_AMOUNT,
+            PaymentMethod.CASH,
+            null,
+            "paidAt must not be null"));
+  }
+}


### PR DESCRIPTION
## Summary

Implements the initial Payments module flow by creating payments based on events published by Orders.

When an order is placed, Payments consumes `OrderPlacedEvent` and creates a corresponding `Payment` aggregate with the correct initial status: `PAID` or `PENDING`.

## Business Value

This enables basic financial tracking for orders, allowing the system to distinguish between:

- orders already paid at the cashier
- orders still waiting for payment, such as delivery orders

It lays the foundation for future payment operations and integrations without introducing direct API coupling between Orders and Payments.

## What changed

- Added `Payment` aggregate
- Added `PaymentMethod`
- Added `PaymentStatus`
- Added `PaymentRepository`
- Added JPA repository adapter for payments
- Added `RegisterPaymentCommand`
- Added `PaymentService`
- Added `OrderPlacedEventListener`
- Added Liquibase migration for the `payments` table
- Added tenant-scoped payment lookup by order
- Added payment creation from `OrderPlacedEvent`

## Design Notes

- Payments are created internally from `OrderPlacedEvent`
- No direct payment API is introduced in this step
- Payment amount comes from the order total
- `paidAt` is managed by the application using `Clock`
- `PAID` payments require `paidAt`
- `PENDING` payments do not have `paidAt`
- The listener acts as an adapter and maps Orders event data into a Payments command
- The Orders event contract is consumed through a Modulith named interface

## Database

Adds the `payments` table with:

- `id`
- `tenant_id`
- `order_id`
- `amount`
- `payment_method`
- `payment_status`
- `paid_at`
- `created_at`
- `updated_at`

Also adds tenant/order indexes and enforces one payment per order for the current MVP scope.

## Tests

Added/updated coverage for:

- creating a paid payment with `paidAt`
- rejecting paid payment without `paidAt`
- creating a pending payment without `paidAt`
- rejecting invalid payment fields
- registering paid payment from application service
- registering pending payment from application service
- persisting payments correctly
- using `Clock` only when payment status is `PAID`

## Out of Scope

- External payment providers
- Direct payment APIs
- Marking pending payment as paid
- Payment retries
- Idempotency
- Partial payments
- Multiple payments per order
- Refunds
- Webhooks
- Payment reconciliation

## Notes

This PR depends on Orders publishing `OrderPlacedEvent`.

Future work will add manual payment operations, such as marking a pending payment as paid.

Closes #74