### PR TITLE
feat(payments): add mark-as-paid use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project currently does not use formal versioned releases. Changes are group
 - Payment creation from `OrderPlacedEvent`.
 - Payment repository port and JPA adapter.
 - Tenant-scoped payment lookup by order.
+- Application use case to mark an order payment as paid by tenant and order.
 - Application-managed `paidAt` handling using `Clock`.
 - Liquibase migration for payments.
 - Global API error response contract.
@@ -70,6 +71,7 @@ This project currently does not use formal versioned releases. Changes are group
 - Prevented repeated status commands from overwriting lifecycle timestamps.
 - Prevented paid payments from being created without `paidAt`.
 - Prevented pending payments from receiving a paid timestamp during creation.
+- Prevented repeated paid-payment commands from overwriting the original `paidAt`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# Oven Platform
+# oven-platform
 
-Oven Platform is a multi-tenant backend platform for restaurant and pizzeria operations.
+Oven Platform is a multi-tenant Java/Spring Boot backend platform for restaurant and pizzeria operations, built as a modular monolith using Spring Modulith.
 
-The project is being built as a modular monolith using Java and Spring Boot, with a strong focus on clean boundaries, tenant isolation, rich domain modeling, automated tests, and production-oriented engineering practices.
+## Project status
+
+This is a personal learning and portfolio project.
+
+I use this repository to practice backend architecture, Spring Boot, modular monolith design,
+domain modeling, testing, observability, and system design decisions.
+
+Issues are used to plan and document my own implementation work.
+
+I am not currently hiring paid contributors for issues in this repository.
+
+---
 
 The current MVP focuses on the foundations required for a SaaS platform:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# oven-platform
+# Oven Platform
 
 Oven Platform is a multi-tenant Java/Spring Boot backend platform for restaurant and pizzeria operations, built as a modular monolith using Spring Modulith.
 

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentService.java
@@ -1,13 +1,15 @@
 package br.com.f2e.ovenplatform.payment.application;
 
+import br.com.f2e.ovenplatform.payment.application.api.MarkOrderPaymentAsPaid;
 import br.com.f2e.ovenplatform.payment.domain.Payment;
 import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import java.time.Clock;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class PaymentService {
+public class PaymentService implements MarkOrderPaymentAsPaid {
 
   private final PaymentRepository paymentRepository;
   private final Clock clock;
@@ -44,5 +46,12 @@ public class PaymentService {
             () ->
                 new ResourceNotFoundException(
                     "Payment for order id: %s not found".formatted(orderId)));
+  }
+
+  @Override
+  @Transactional
+  public void markAsPaid(UUID tenantId, UUID orderId) {
+    var payment = findByTenantIdAndOrderId(tenantId, orderId);
+    payment.markAsPaid(clock.instant());
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/api/MarkOrderPaymentAsPaid.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/api/MarkOrderPaymentAsPaid.java
@@ -1,0 +1,7 @@
+package br.com.f2e.ovenplatform.payment.application.api;
+
+import java.util.UUID;
+
+public interface MarkOrderPaymentAsPaid {
+  void markAsPaid(UUID tenantId, UUID orderId);
+}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/api/package-info.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/api/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("api")
+package br.com.f2e.ovenplatform.payment.application.api;

--- a/src/main/java/br/com/f2e/ovenplatform/payment/domain/Payment.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/domain/Payment.java
@@ -28,11 +28,11 @@ public class Payment extends BaseEntity {
 
   @Enumerated(EnumType.STRING)
   @Column(name = "method", nullable = false)
-  private PaymentMethod paymentMethod;
+  private PaymentMethod method;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)
-  private PaymentStatus paymentStatus;
+  private PaymentStatus status;
 
   @Column(name = "paid_at")
   private Instant paidAt;
@@ -43,14 +43,14 @@ public class Payment extends BaseEntity {
       UUID tenantId,
       UUID orderId,
       BigDecimal amount,
-      PaymentMethod paymentMethod,
-      PaymentStatus paymentStatus,
+      PaymentMethod method,
+      PaymentStatus status,
       Instant paidAt) {
     this.tenantId = requireNotNull(tenantId, "tenantId");
     this.orderId = requireNotNull(orderId, "orderId");
     this.amount = requirePositive(amount, "amount");
-    this.paymentMethod = requireNotNull(paymentMethod, "paymentMethod");
-    this.paymentStatus = requireNotNull(paymentStatus, "paymentStatus");
+    this.method = requireNotNull(method, "paymentMethod");
+    this.status = requireNotNull(status, "paymentStatus");
     this.paidAt = paidAt;
   }
 
@@ -77,15 +77,23 @@ public class Payment extends BaseEntity {
     return amount;
   }
 
-  public PaymentMethod getPaymentMethod() {
-    return paymentMethod;
+  public PaymentMethod getMethod() {
+    return method;
   }
 
-  public PaymentStatus getPaymentStatus() {
-    return paymentStatus;
+  public PaymentStatus getStatus() {
+    return status;
   }
 
   public Instant getPaidAt() {
     return paidAt;
+  }
+
+  public void markAsPaid(Instant paidAt) {
+    if (status == PaymentStatus.PAID) {
+      return;
+    }
+    status = PaymentStatus.PAID;
+    this.paidAt = requireNotNull(paidAt, "paidAt");
   }
 }

--- a/src/test/java/br/com/f2e/ovenplatform/payment/application/PaymentServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/payment/application/PaymentServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import br.com.f2e.ovenplatform.payment.domain.Payment;
 import br.com.f2e.ovenplatform.payment.domain.PaymentMethod;
 import br.com.f2e.ovenplatform.payment.domain.PaymentStatus;
 import br.com.f2e.ovenplatform.payment.infrastructure.persistence.JpaPaymentRepositoryAdapter;
@@ -58,8 +59,8 @@ class PaymentServiceIntegrationTest {
     assertThat(payment.getTenantId()).isEqualTo(TENANT_ID);
     assertThat(payment.getOrderId()).isEqualTo(ORDER_ID);
     assertThat(payment.getAmount()).isEqualByComparingTo("20.00");
-    assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
-    assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.PAID);
+    assertThat(payment.getMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
     assertThat(payment.getPaidAt()).isEqualTo(PAID_AT);
 
     verify(clock).instant();
@@ -79,8 +80,8 @@ class PaymentServiceIntegrationTest {
     assertThat(payment.getTenantId()).isEqualTo(TENANT_ID);
     assertThat(payment.getOrderId()).isEqualTo(ORDER_ID);
     assertThat(payment.getAmount()).isEqualByComparingTo("20.00");
-    assertThat(payment.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
-    assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
+    assertThat(payment.getMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PENDING);
     assertThat(payment.getPaidAt()).isNull();
 
     verifyNoInteractions(clock);
@@ -91,6 +92,25 @@ class PaymentServiceIntegrationTest {
     assertThatThrownBy(() -> paymentService.findByTenantIdAndOrderId(TENANT_ID, ORDER_ID))
         .isInstanceOf(ResourceNotFoundException.class)
         .hasMessage("Payment for order id: %s not found".formatted(ORDER_ID));
+  }
+
+  @Test
+  void shouldMarkPendingPaymentAsPaidByOrderId() {
+    when(clock.instant()).thenReturn(PAID_AT);
+
+    var payment = Payment.pending(TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH);
+    paymentRepository.save(payment);
+
+    paymentService.markAsPaid(TENANT_ID, ORDER_ID);
+
+    flushAndClear();
+
+    var persistedPayment = paymentService.findByTenantIdAndOrderId(TENANT_ID, ORDER_ID);
+
+    assertThat(persistedPayment.getStatus()).isEqualTo(PaymentStatus.PAID);
+    assertThat(persistedPayment.getPaidAt()).isEqualTo(PAID_AT);
+
+    verify(clock).instant();
   }
 
   private void flushAndClear() {

--- a/src/test/java/br/com/f2e/ovenplatform/payment/domain/PaymentTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/payment/domain/PaymentTest.java
@@ -27,9 +27,9 @@ class PaymentTest {
 
     assertThat(paymentPaid.getTenantId()).isEqualTo(TENANT_ID);
     assertThat(paymentPaid.getOrderId()).isEqualTo(ORDER_ID);
-    assertThat(paymentPaid.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(paymentPaid.getMethod()).isEqualTo(PaymentMethod.CASH);
     assertThat(paymentPaid.getPaidAt()).isEqualTo(PAID_AT);
-    assertThat(paymentPaid.getPaymentStatus()).isEqualTo(PaymentStatus.PAID);
+    assertThat(paymentPaid.getStatus()).isEqualTo(PaymentStatus.PAID);
     assertThat(paymentPaid.getAmount()).isEqualByComparingTo("20.00");
   }
 
@@ -48,9 +48,9 @@ class PaymentTest {
 
     assertThat(pendingPayment.getTenantId()).isEqualTo(TENANT_ID);
     assertThat(pendingPayment.getOrderId()).isEqualTo(ORDER_ID);
-    assertThat(pendingPayment.getPaymentMethod()).isEqualTo(PaymentMethod.CASH);
+    assertThat(pendingPayment.getMethod()).isEqualTo(PaymentMethod.CASH);
     assertThat(pendingPayment.getPaidAt()).isNull();
-    assertThat(pendingPayment.getPaymentStatus()).isEqualTo(PaymentStatus.PENDING);
+    assertThat(pendingPayment.getStatus()).isEqualTo(PaymentStatus.PENDING);
     assertThat(pendingPayment.getAmount()).isEqualByComparingTo("20.00");
   }
 
@@ -66,6 +66,38 @@ class PaymentTest {
     assertThatThrownBy(() -> Payment.paid(tenantId, orderId, paymentAmount, paymentMethod, paidAt))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(expectedMessage);
+  }
+
+  @Test
+  void shouldMarkPendingPaymentAsPaid() {
+
+    var payment = Payment.pending(TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH);
+
+    payment.markAsPaid(PAID_AT);
+
+    assertThat(payment.getPaidAt()).isEqualTo(PAID_AT);
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+  }
+
+  @Test
+  void shouldKeepAlreadyPaidPaymentUnchanged() {
+
+    var payment = Payment.paid(TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH, PAID_AT);
+    var secondPaymentTime = Instant.parse("2026-05-12T21:00:00Z");
+
+    payment.markAsPaid(secondPaymentTime);
+
+    assertThat(payment.getPaidAt()).isEqualTo(PAID_AT);
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+  }
+
+  @Test
+  void shouldRejectMarkAsPaidWithoutPaidAt() {
+    var payment = Payment.pending(TENANT_ID, ORDER_ID, PAYMENT_AMOUNT, PaymentMethod.CASH);
+
+    assertThatThrownBy(() -> payment.markAsPaid(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("paidAt must not be null");
   }
 
   private static Stream<Arguments> invalidPaidPayments() {


### PR DESCRIPTION
## Summary

Adds a Payments application use case to mark the payment associated with an order as paid.

This introduces the Payments-side flow for transitioning a pending payment to paid by using `tenantId + orderId`, while keeping payment state and financial rules owned by the Payments module.

## Business Value

Restaurant staff need a way to close pending payments after money is collected, especially for delivery or phone orders where the order may be created before payment is received.

This change prepares the system for a future Orders-facing operational endpoint while keeping the actual payment transition inside Payments.

## What changed

- Added domain behavior to mark a `Payment` as paid
- Added idempotent handling for repeated `PAID -> PAID` commands
- Preserved the original `paidAt` when a payment is already paid
- Added validation to prevent marking a payment as paid without `paidAt`
- Added `MarkOrderPaymentAsPaid` application API port
- Exposed the Payments application API through a Modulith named interface
- Implemented the mark-as-paid use case in `PaymentService`
- Updated Payments tests
- Updated README project status
- Updated CHANGELOG

## Design Notes

- Payments remains the owner of payment state and payment transitions
- The use case identifies payments by `tenantId + orderId`
- `paidAt` is set using the injected `Clock` when transitioning from `PENDING` to `PAID`
- Repeated mark-as-paid calls are idempotent and do not overwrite `paidAt`
- No HTTP controller is added in this PR
- Orders is not changed in this PR
- The new application API prepares Orders to consume Payments through a module boundary in a future issue

## Tests

Added/updated coverage for:

- marking a pending payment as paid
- idempotent behavior when payment is already paid
- preserving the original `paidAt`
- rejecting mark-as-paid without `paidAt`
- marking a pending payment as paid through the application service and persisting the result
- tenant/order payment lookup not found behavior through existing service coverage

## Out of Scope

- Orders endpoint/controller changes
- Orders calling the Payments use case
- Direct public payment API
- Partial payments
- Multiple payments per order
- Refunds
- External payment providers
- Webhooks
- Idempotency keys
- Payment reconciliation

Closes #81