### PR TITLE
feat(orders): add payment mark-as-paid event flow

### DIFF
--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/OrderService.java
@@ -1,5 +1,6 @@
 package br.com.f2e.ovenplatform.orders.application;
 
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMarkedAsPaidEvent;
 import br.com.f2e.ovenplatform.orders.application.event.OrderPlacedEvent;
 import br.com.f2e.ovenplatform.orders.domain.Order;
 import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
@@ -105,6 +106,16 @@ public class OrderService {
   @Transactional
   public void cancel(UUID tenantId, UUID orderId) {
     updateOrder(tenantId, orderId, order -> order.cancel(clock.instant()));
+  }
+
+  @Transactional
+  public void markPaymentAsPaid(UUID tenantId, UUID orderId) {
+    var order =
+        orderRepository
+            .findByIdAndTenantId(orderId, tenantId)
+            .orElseThrow(() -> new ResourceNotFoundException(RESOURCE, orderId));
+    eventPublisher.publishEvent(
+        new OrderPaymentMarkedAsPaidEvent(order.getTenantId(), order.getId()));
   }
 
   private void updateOrder(UUID tenantId, UUID orderId, Consumer<Order> operation) {

--- a/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPaymentMarkedAsPaidEvent.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/application/event/OrderPaymentMarkedAsPaidEvent.java
@@ -1,0 +1,5 @@
+package br.com.f2e.ovenplatform.orders.application.event;
+
+import java.util.UUID;
+
+public record OrderPaymentMarkedAsPaidEvent(UUID tenantId, UUID orderId) {}

--- a/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
+++ b/src/main/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderController.java
@@ -77,4 +77,11 @@ public class OrderController {
     var orders = orderService.listOrders(tenantId).stream().map(OrderResponse::from).toList();
     return ResponseEntity.ok(orders);
   }
+
+  @PostMapping(version = API_VERSION_VALUE, path = "/{orderId}/payment/mark-paid")
+  public ResponseEntity<Void> markAsPaid(
+      @RequestHeader(TENANT_ID_HEADER) UUID tenantId, @PathVariable UUID orderId) {
+    orderService.markPaymentAsPaid(tenantId, orderId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentService.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/PaymentService.java
@@ -1,6 +1,5 @@
 package br.com.f2e.ovenplatform.payment.application;
 
-import br.com.f2e.ovenplatform.payment.application.api.MarkOrderPaymentAsPaid;
 import br.com.f2e.ovenplatform.payment.domain.Payment;
 import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import java.time.Clock;
@@ -9,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-public class PaymentService implements MarkOrderPaymentAsPaid {
+public class PaymentService {
 
   private final PaymentRepository paymentRepository;
   private final Clock clock;
@@ -19,6 +18,7 @@ public class PaymentService implements MarkOrderPaymentAsPaid {
     this.clock = clock;
   }
 
+  @Transactional
   public void registerPaymentFromOrder(RegisterPaymentCommand paymentCommand) {
     var payment =
         switch (paymentCommand.paymentStatus()) {
@@ -39,19 +39,23 @@ public class PaymentService implements MarkOrderPaymentAsPaid {
     paymentRepository.save(payment);
   }
 
+  @Transactional(readOnly = true)
   public Payment findByTenantIdAndOrderId(UUID tenantId, UUID orderId) {
+    return getByTenantIdAndOrderId(tenantId, orderId);
+  }
+
+  @Transactional
+  public void markAsPaid(UUID tenantId, UUID orderId) {
+    var payment = getByTenantIdAndOrderId(tenantId, orderId);
+    payment.markAsPaid(clock.instant());
+  }
+
+  private Payment getByTenantIdAndOrderId(UUID tenantId, UUID orderId) {
     return paymentRepository
         .findByTenantIdAndOrderId(tenantId, orderId)
         .orElseThrow(
             () ->
                 new ResourceNotFoundException(
                     "Payment for order id: %s not found".formatted(orderId)));
-  }
-
-  @Override
-  @Transactional
-  public void markAsPaid(UUID tenantId, UUID orderId) {
-    var payment = findByTenantIdAndOrderId(tenantId, orderId);
-    payment.markAsPaid(clock.instant());
   }
 }

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/api/MarkOrderPaymentAsPaid.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/api/MarkOrderPaymentAsPaid.java
@@ -1,7 +1,0 @@
-package br.com.f2e.ovenplatform.payment.application.api;
-
-import java.util.UUID;
-
-public interface MarkOrderPaymentAsPaid {
-  void markAsPaid(UUID tenantId, UUID orderId);
-}

--- a/src/main/java/br/com/f2e/ovenplatform/payment/application/api/package-info.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/application/api/package-info.java
@@ -1,2 +1,0 @@
-@org.springframework.modulith.NamedInterface("api")
-package br.com.f2e.ovenplatform.payment.application.api;

--- a/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/event/OrderPaymentMarkedAsPaidEventListener.java
+++ b/src/main/java/br/com/f2e/ovenplatform/payment/infrastructure/event/OrderPaymentMarkedAsPaidEventListener.java
@@ -1,0 +1,21 @@
+package br.com.f2e.ovenplatform.payment.infrastructure.event;
+
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMarkedAsPaidEvent;
+import br.com.f2e.ovenplatform.payment.application.PaymentService;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderPaymentMarkedAsPaidEventListener {
+
+  private final PaymentService paymentService;
+
+  public OrderPaymentMarkedAsPaidEventListener(PaymentService paymentService) {
+    this.paymentService = paymentService;
+  }
+
+  @ApplicationModuleListener
+  public void on(OrderPaymentMarkedAsPaidEvent event) {
+    paymentService.markAsPaid(event.tenantId(), event.orderId());
+  }
+}

--- a/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/application/OrderServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMarkedAsPaidEvent;
 import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMethod;
 import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentStatus;
 import br.com.f2e.ovenplatform.orders.application.event.OrderPlacedEvent;
@@ -286,6 +287,39 @@ class OrderServiceIntegrationTest {
               assertThat(order.getDeliveredAt()).isNull();
               assertThat(order.getCancelledAt()).isEqualTo(occurredAt);
             });
+  }
+
+  @Test
+  void shouldPublishEventWhenMarkingOrderPaymentAsPaid() {
+    var savedOrder = orderService.save(createOrderWithItems(TENANT_ID, 1));
+
+    flushAndClear();
+
+    orderService.markPaymentAsPaid(savedOrder.getTenantId(), savedOrder.getId());
+
+    flushAndClear();
+
+    var markedAsPaidEvents = applicationEvents.stream(OrderPaymentMarkedAsPaidEvent.class).toList();
+
+    assertThat(markedAsPaidEvents).hasSize(1);
+
+    var paidEvent = markedAsPaidEvents.getFirst();
+
+    assertThat(paidEvent.orderId()).isEqualTo(savedOrder.getId());
+    assertThat(paidEvent.tenantId()).isEqualTo(savedOrder.getTenantId());
+  }
+
+  @Test
+  void shouldNotPublishEventWhenOrderDoesNotExist() {
+    var orderId = UUID.randomUUID();
+
+    assertThatThrownBy(() -> orderService.markPaymentAsPaid(TENANT_ID, orderId))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .hasMessage("Order id: %s not found".formatted(orderId));
+
+    var events = applicationEvents.stream(OrderPaymentMarkedAsPaidEvent.class).toList();
+
+    assertThat(events).isEmpty();
   }
 
   private void flushAndClear() {

--- a/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/orders/infrastructure/web/OrderControllerTest.java
@@ -32,6 +32,7 @@ import br.com.f2e.ovenplatform.orders.infrastructure.web.dto.CreateOrderRequest;
 import br.com.f2e.ovenplatform.orders.infrastructure.web.dto.OrderItemRequest;
 import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import br.com.f2e.ovenplatform.shared.infrastructure.tracing.TraceContext;
+import br.com.f2e.ovenplatform.shared.infrastructure.web.ApiHeaders;
 import br.com.f2e.ovenplatform.shared.infrastructure.web.exception.ApiErrorCodes;
 import br.com.f2e.ovenplatform.shared.util.JsonUtils;
 import java.math.BigDecimal;
@@ -343,6 +344,21 @@ class OrderControllerTest {
         .andExpect(jsonPath(secondOrderJson + ".items[0].subtotal").value(50.60));
 
     verify(orderService).listOrders(TENANT_ID);
+  }
+
+  @Test
+  void shouldMarkOrderPaymentAsPaid() throws Exception {
+    var orderId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post(BASE_URL + "/" + orderId + "/payment/mark-paid")
+                .accept(MediaType.APPLICATION_JSON)
+                .header(ApiHeaders.TENANT_ID_HEADER, TENANT_ID)
+                .header(ApiHeaders.API_VERSION_HEADER, ApiHeaders.API_VERSION_VALUE))
+        .andExpect(status().isNoContent());
+
+    verify(orderService).markPaymentAsPaid(TENANT_ID, orderId);
   }
 
   private Order createOrder(

--- a/src/test/java/br/com/f2e/ovenplatform/payment/application/PaymentServiceIntegrationTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/payment/application/PaymentServiceIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import br.com.f2e.ovenplatform.payment.domain.Payment;
 import br.com.f2e.ovenplatform.payment.domain.PaymentMethod;
 import br.com.f2e.ovenplatform.payment.domain.PaymentStatus;
+import br.com.f2e.ovenplatform.payment.infrastructure.event.OrderPaymentMarkedAsPaidEventListener;
 import br.com.f2e.ovenplatform.payment.infrastructure.persistence.JpaPaymentRepositoryAdapter;
 import br.com.f2e.ovenplatform.shared.application.exception.ResourceNotFoundException;
 import jakarta.persistence.EntityManager;
@@ -26,7 +27,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({PaymentService.class, JpaPaymentRepositoryAdapter.class})
+@Import({
+  PaymentService.class,
+  JpaPaymentRepositoryAdapter.class,
+  OrderPaymentMarkedAsPaidEventListener.class
+})
 @EnableJpaAuditing
 class PaymentServiceIntegrationTest {
 

--- a/src/test/java/br/com/f2e/ovenplatform/payment/infrastructure/event/OrderPaymentMarkedAsPaidEventListenerTest.java
+++ b/src/test/java/br/com/f2e/ovenplatform/payment/infrastructure/event/OrderPaymentMarkedAsPaidEventListenerTest.java
@@ -1,0 +1,30 @@
+package br.com.f2e.ovenplatform.payment.infrastructure.event;
+
+import static org.mockito.Mockito.verify;
+
+import br.com.f2e.ovenplatform.orders.application.event.OrderPaymentMarkedAsPaidEvent;
+import br.com.f2e.ovenplatform.payment.application.PaymentService;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OrderPaymentMarkedAsPaidEventListenerTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecc");
+  private static final UUID ORDER_ID = UUID.fromString("a6210129-f1d5-4942-8d0a-b144e518aecd");
+
+  @Mock private PaymentService paymentService;
+
+  @InjectMocks private OrderPaymentMarkedAsPaidEventListener listener;
+
+  @Test
+  void shouldMarkPaymentAsPaidWhenReceivingEvent() {
+    listener.on(new OrderPaymentMarkedAsPaidEvent(TENANT_ID, ORDER_ID));
+
+    verify(paymentService).markAsPaid(TENANT_ID, ORDER_ID);
+  }
+}


### PR DESCRIPTION
## Summary

Adds an Orders operational flow to mark an order payment as paid, using an event-driven integration with the Payments module.

This PR introduces an Orders endpoint that publishes an application event, and a Payments listener that consumes that event and performs the payment transition.

## What changed

- Added endpoint:
  - `POST /orders/{orderId}/payment/mark-paid`
- Orders now publishes `OrderPaymentMarkedAsPaidEvent`
- Payments consumes the event and marks the payment as paid
- Removed direct Payments application API (`MarkOrderPaymentAsPaid`)
- Removed `payment.application.api` named interface
- Added listener:
  - `OrderPaymentMarkedAsPaidEventListener`
- Updated `PaymentService` to be used internally by the listener
- Added/updated tests:
  - Orders integration tests for event publication
  - Payments integration test for mark-as-paid behavior
  - Listener unit test verifying delegation to `PaymentService`

## Design Notes

The initial approach used a direct Orders → Payments application API call. This created a dependency cycle because Payments already consumes Orders events.

This PR switches to an event-driven approach:

- Orders validates the order exists for the tenant
- Orders publishes `OrderPaymentMarkedAsPaidEvent`
- Payments consumes the event
- Payments performs the payment transition internally

This keeps payment rules inside the Payments module while avoiding a Spring Modulith cycle.

## Tests

- Controller test verifies the Orders endpoint returns `204 No Content` and delegates to `OrderService`.
- Orders integration tests verify event publication and no event publication when the order does not exist.
- Payments integration tests verify marking a pending payment as paid.
- Listener unit test verifies delegation to `PaymentService`.

## Out of Scope

- Payment API exposure
- Refunds, partial payments, or external providers

Closes #83